### PR TITLE
Cast 'current_offset' into integer to prevent "TypeError" if re-running script after crash.

### DIFF
--- a/python/ch04_listing_source.py
+++ b/python/ch04_listing_source.py
@@ -1,4 +1,3 @@
-
 import os
 import time
 import unittest
@@ -52,6 +51,7 @@ def process_logs(conn, path, callback):                     #K
             current_offset = 0
 
         current_file = None
+        current_offset = int(current_offset)
 
         for lno, line in enumerate(inp):                    #L
             callback(pipe, line)                            #E


### PR DESCRIPTION
Cast 'current_offset' into an integer, as this will throw a "TypeError" since this is a string read from Redis on subsequent runs of script (simulating a crash and restarting from offset); it would not be noticed on initial run, since it starts as an integer.
