### PR TITLE
Small bugfix to daily_country_aggregate()

### DIFF
--- a/python/ch06_listing_source.py
+++ b/python/ch06_listing_source.py
@@ -607,8 +607,8 @@ def leave_chat(conn, chat_id, user):
 aggregates = defaultdict(lambda: defaultdict(int))      #A
 
 def daily_country_aggregate(conn, line):
-    line = line.split()
     if line:
+        line = line.split()
         ip = line[0]                                    #B
         day = line[1]                                   #B
         country = find_city_by_ip_local(ip)[2]          #C


### PR DESCRIPTION
When None is passed in to cause the aggregates to flush, the split() call on the None argument will cause an exception. Move the split() call inside the if statement.
