### PR TITLE
Fix the TTL checking of the lock

### DIFF
--- a/python/ch06_listing_source.py
+++ b/python/ch06_listing_source.py
@@ -245,7 +245,7 @@ def acquire_lock_with_timeout(
         if conn.setnx(lockname, identifier):            #B
             conn.expire(lockname, lock_timeout)         #B
             return identifier
-        elif not conn.ttl(lockname):                    #C
+        elif conn.ttl(lockname) < 0:                    #C
             conn.expire(lockname, lock_timeout)         #C
 
         time.sleep(.001)


### PR DESCRIPTION
The `ttl` command return `-2` if the key does not exist or `-1` if the key exists but has no associated expire. 
Should use `conn.ttl(key) < 0` instead of `not conn.ttl(key)` to check whether a key's ttl is not set.