### PR TITLE
consider the existing key to be null situation

### DIFF
--- a/python/ch05_listing_source.py
+++ b/python/ch05_listing_source.py
@@ -209,11 +209,14 @@ def update_stats(conn, context, type, value, timeout=5):
 
             existing = pipe.get(start_key)
             pipe.multi()
-            if existing and existing < hour_start:
+            
+            if not existing:
+                pipe.set(start_key, hour_start)
+            elif existing < hour_start:
                 pipe.rename(destination, destination + ':last') #B
                 pipe.rename(start_key, destination + ':pstart') #B
                 pipe.set(start_key, hour_start)                 #B
-
+ 
             tkey1 = str(uuid.uuid4())
             tkey2 = str(uuid.uuid4())
             pipe.zadd(tkey1, 'min', value)                      #C


### PR DESCRIPTION
Code in 《Redis in Action》 chapter 5 example 5-6 has such problem:
if this is the first time to start update_stats(...) function,it can not be able to initialize the 'start_key' which equals "destination+':start'“,because the code "if existing and existing < hour_start" has not think the situation that "existing" key can be null at the very beginning,while no place initialize existing_key.