### PR TITLE
python/ch01_listing_source.py line 187 conn.hmset -> conn.hset

### DIFF
--- a/python/ch01_listing_source.py
+++ b/python/ch01_listing_source.py
@@ -184,7 +184,7 @@ def post_article(conn, user, title, link):
 
     now = time.time()
     article = 'article:' + article_id
-    conn.hmset(article, {                       #C
+    conn.hset(article, mapping={                #C
         'title': title,                         #C
         'link': link,                           #C
         'poster': user,                         #C


### PR DESCRIPTION
Changed hmset to hset, since it caused Deprecation warning on 7.0.7 version of redis. Ran the script, everything is clear.