### PR TITLE
Bringing Redis service up in python/docker-compose.yml

### DIFF
--- a/python/ch01_listing_source.py
+++ b/python/ch01_listing_source.py
@@ -260,7 +260,7 @@ def get_group_articles(conn, group, page, order='score:'):
 class TestCh01(unittest.TestCase):
     def setUp(self):
         import redis
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
 
     def tearDown(self):
         del self.conn

--- a/python/ch02_listing_source.py
+++ b/python/ch02_listing_source.py
@@ -234,7 +234,7 @@ class Inventory(object):
 class TestCh02(unittest.TestCase):
     def setUp(self):
         import redis
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
 
     def tearDown(self):
         conn = self.conn

--- a/python/ch04_listing_source.py
+++ b/python/ch04_listing_source.py
@@ -287,7 +287,7 @@ LRANGE (first 600 elements): 9041.59 requests per second
 class TestCh04(unittest.TestCase):
     def setUp(self):
         import redis
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
         self.conn.flushdb()
 
     def tearDown(self):

--- a/python/ch05_listing_source.py
+++ b/python/ch05_listing_source.py
@@ -220,7 +220,7 @@ def update_stats(conn, context, type, value, timeout=5):
             
             if not existing:
                 pipe.set(start_key, hour_start)
-            elif existing < hour_start:
+            elif existing < bytes(hour_start, encoding='utf-8'):
                 pipe.rename(destination, destination + ':last') #B
                 pipe.rename(start_key, destination + ':pstart') #B
                 pipe.set(start_key, hour_start)                 #B
@@ -446,7 +446,7 @@ def redis_connection(component, wait=1):                        #A
                 config_connection, 'redis', component, wait)    #G
 
             if config != old_config:                            #H
-                REDIS_CONNECTIONS[key] = redis.Redis(**config)  #H
+                REDIS_CONNECTIONS[key] = redis.Redis(host="redis-in-action-redis", **config)  #H
 
             return function(                                    #I
                 REDIS_CONNECTIONS.get(key), *args, **kwargs)    #I
@@ -527,7 +527,7 @@ class TestCh05(unittest.TestCase):
     def setUp(self):
         global config_connection
         import redis
-        self.conn = config_connection = redis.Redis(db=15)
+        self.conn = config_connection = redis.Redis(host="redis-in-action-redis", db=15)
         self.conn.flushdb()
 
     def tearDown(self):

--- a/python/ch06_listing_source.py
+++ b/python/ch06_listing_source.py
@@ -809,7 +809,7 @@ def readblocks_gz(conn, key):
 class TestCh06(unittest.TestCase):
     def setUp(self):
         import redis
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
 
     def tearDown(self):
         self.conn.flushdb()

--- a/python/ch07_listing_source.py
+++ b/python/ch07_listing_source.py
@@ -676,7 +676,7 @@ def search_job_years(conn, skill_years):
 class TestCh07(unittest.TestCase):
     content = 'this is some random content, look at how it is indexed.'
     def setUp(self):
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
         self.conn.flushdb()
     def tearDown(self):
         self.conn.flushdb()

--- a/python/ch08_listing_source.py
+++ b/python/ch08_listing_source.py
@@ -894,7 +894,7 @@ if __name__ == '__main__':                  #A
 
 class TestCh08(unittest.TestCase):
     def setUp(self):
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
         self.conn.flushdb()
     def tearDown(self):
         self.conn.flushdb()

--- a/python/ch09_listing_source.py
+++ b/python/ch09_listing_source.py
@@ -485,7 +485,7 @@ def aggregate_location_list(conn, user_ids):
 
 class TestCh09(unittest.TestCase):
     def setUp(self):
-        self.conn = redis.Redis(db=15, encoding='latin-1')
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15, encoding='latin-1')
         self.conn.flushdb()
     def tearDown(self):
         self.conn.flushdb()

--- a/python/ch10_listing_source.py
+++ b/python/ch10_listing_source.py
@@ -46,7 +46,7 @@ def redis_connection(component, wait=1):                        #A
             config = _config
 
             if config != old_config:                            #H
-                REDIS_CONNECTIONS[key] = redis.Redis(**config)  #H
+                REDIS_CONNECTIONS[key] = redis.Redis(host="redis-in-action-redis", **config)  #H
 
             return function(                                    #I
                 REDIS_CONNECTIONS.get(key), *args, **kwargs)    #I
@@ -155,7 +155,7 @@ def get_redis_connection(component, wait=1):
         config_connection, 'redis', component, wait)    #B
 
     if config != old_config:                            #C
-        REDIS_CONNECTIONS[key] = redis.Redis(**config)  #C
+        REDIS_CONNECTIONS[key] = redis.Redis(host="redis-in-action-redis", **config)  #C
 
     return REDIS_CONNECTIONS.get(key)                   #D
 # <end id="get-connection"/>
@@ -585,7 +585,7 @@ def syndicate_status(uid, post, start=0, on_lists=False):
                 timeline, 0, -HOME_TIMELINE_SIZE-1)     #G
         pipe.execute()
 
-    conn = redis.Redis()
+    conn = redis.Redis(host="redis-in-action-redis")
     if len(followers) >= POSTS_PER_PASS:
         execute_later(conn, 'default', 'syndicate_status',
             [uid, post, start, on_lists])
@@ -612,13 +612,13 @@ def _fake_shards_for(conn, component, count, actual):
 class TestCh10(unittest.TestCase):
     def _flush(self):
         self.conn.flushdb()
-        redis.Redis(db=14).flushdb()
-        redis.Redis(db=13).flushdb()
-        redis.Redis(db=12).flushdb()
-        redis.Redis(db=11).flushdb()
+        redis.Redis(host="redis-in-action-redis", db=14).flushdb()
+        redis.Redis(host="redis-in-action-redis", db=13).flushdb()
+        redis.Redis(host="redis-in-action-redis", db=12).flushdb()
+        redis.Redis(host="redis-in-action-redis", db=11).flushdb()
         
     def setUp(self):
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
         self._flush()
         global config_connection
         config_connection = self.conn
@@ -633,8 +633,8 @@ class TestCh10(unittest.TestCase):
         for i in range(10):
             get_sharded_connection('shard', i, 2).sadd('foo', i)
 
-        s0 = redis.Redis(db=14).scard('foo')
-        s1 = redis.Redis(db=13).scard('foo')
+        s0 = redis.Redis(host="redis-in-action-redis", db=14).scard('foo')
+        s1 = redis.Redis(host="redis-in-action-redis", db=13).scard('foo')
         self.assertTrue(s0 < 10)
         self.assertTrue(s1 < 10)
         self.assertEqual(s0 + s1, 10)
@@ -650,7 +650,7 @@ class TestCh10(unittest.TestCase):
         base = 'unique:%s'%date.today().isoformat()
         total = 0
         for c in shards:
-            conn = redis.Redis(**c)
+            conn = redis.Redis(host="redis-in-action-redis", **c)
             keys = conn.keys(base + ':*')
             for k in keys:
                 cnt = conn.scard(k)
@@ -710,7 +710,7 @@ class TestCh10(unittest.TestCase):
         self.assertEqual(sharded_timelines['home:1'].zcard('home:1'), 9)
         
         for db in range(14, 10, -1):
-            self.assertTrue(len(list(redis.Redis(db=db).keys())) > 0)
+            self.assertTrue(len(list(redis.Redis(host="redis-in-action-redis", db=db).keys())) > 0)
         for u2 in range(2, 11):
             self.assertEqual(self.conn.zcard('followers:%i'%u2), 1)
             self.assertEqual(self.conn.zcard('following:%i'%u2), 1)
@@ -729,7 +729,7 @@ class TestCh10(unittest.TestCase):
         
         allkeys = defaultdict(int)
         for db in range(14, 10, -1):
-            c = redis.Redis(db=db)
+            c = redis.Redis(host="redis-in-action-redis", db=db)
             for k in list(c.keys()):
                 allkeys[k] += c.zcard(k)
 

--- a/python/ch11_listing_source.py
+++ b/python/ch11_listing_source.py
@@ -606,7 +606,7 @@ end
 
 class TestCh11(unittest.TestCase):
     def setUp(self):
-        self.conn = redis.Redis(db=15)
+        self.conn = redis.Redis(host="redis-in-action-redis", db=15)
         self.conn.flushdb()
     def tearDown(self):
         self.conn.flushdb()

--- a/python/docker-compose.yml
+++ b/python/docker-compose.yml
@@ -8,11 +8,10 @@ services:
     tty: true
     volumes:
       - ".:/usr/src/app"
-    network_mode: "host"
-
+    depends_on:
+      - redis
   redis:
     image: "redis:latest"
     container_name: "redis-in-action-redis"
     ports:
       - "6379:6379"
-    network_mode: "host"


### PR DESCRIPTION
The aim of this PR is bringing Redis service up as reported as never up in #96. After implementing a fix in python/docker-compose.yml, the Redis service is up as detailed below.
 
 ```sh
 @rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $ docker-compose up -d
Pulling redis (redis:latest)...
latest: Pulling from library/redis
f1f26f570256: Pull complete
8a1809b0503d: Pull complete
d792b14d05f9: Pull complete
ad29eaf93bf6: Pull complete
7cda84ccdb33: Pull complete
95f837a5984d: Pull complete
Digest: sha256:7b83a0167532d4320a87246a815a134e19e31504d85e8e55f0bb5bb9edf70448
Status: Downloaded newer image for redis:latest
Building python
[+] Building 1.5s (10/10) FINISHED                                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                                       0.2s
 => => transferring dockerfile: 34B                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                          0.3s
 => => transferring context: 2B                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/python:3.6                                                                                                              0.8s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                                              0.0s
 => [1/4] FROM docker.io/library/python:3.6@sha256:f8652afaf88c25f0d22354d547d892591067aa4026a7fa9a6819df9f300af6fc                                                        0.0s
 => [internal] load build context                                                                                                                                          0.1s
 => => transferring context: 37B                                                                                                                                           0.0s
 => CACHED [2/4] WORKDIR /usr/src/app                                                                                                                                      0.0s
 => CACHED [3/4] COPY requirements.txt ./                                                                                                                                  0.0s
 => CACHED [4/4] RUN pip install --no-cache-dir -r requirements.txt                                                                                                        0.0s
 => exporting to image                                                                                                                                                     0.2s
 => => exporting layers                                                                                                                                                    0.0s
 => => writing image sha256:2130d016f3b65f51f29038dd31108061b43ec6a19c212e86967e74ab04e0eaaa                                                                               0.0s
 => => naming to docker.io/library/python:redis-in-action                                                                                                                  0.0s
WARNING: Image for service python was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating redis-in-action-redis ... done
Creating redis-in-action-python ... done
@rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $ docker container ls
CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS                                       NAMES
9d4dc1787011   python:redis-in-action   "python3"                33 seconds ago   Up 31 seconds                                               redis-in-action-python
ec41872ecd28   redis:latest             "docker-entrypoint.s…"   34 seconds ago   Up 32 seconds   0.0.0.0:6379->6379/tcp, :::6379->6379/tcp   redis-in-action-redis
@rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $
 ```
 As indicated in `python/README-DOCKER.md`, I have used `ch01_listing_source.py` to test this PR and turns out that the Python script generates an error:
 
 ```sh
@rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $ docker exec -it redis-in-action-python python ch01_listing_source.py


E
======================================================================
ERROR: test_article_functionality (__main__.TestCh01)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 612, in connect
    lambda: self._connect(), lambda error: self.disconnect(error)
  File "/usr/local/lib/python3.6/site-packages/redis/retry.py", line 46, in call_with_retry
    return do()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 612, in <lambda>
    lambda: self._connect(), lambda error: self.disconnect(error)
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 677, in _connect
    raise err
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 665, in _connect
    sock.connect(socket_address)
OSError: [Errno 99] Cannot assign requested address

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "ch01_listing_source.py", line 274, in test_article_functionality
    article_id = str(post_article(conn, 'username', 'A title', 'http://www.google.com'))
  File "ch01_listing_source.py", line 179, in post_article
    article_id = str(conn.incr('article:'))     #A
  File "/usr/local/lib/python3.6/site-packages/redis/commands/core.py", line 1831, in incrby
    return self.execute_command("INCRBY", name, amount)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 1235, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 1387, in get_connection
    connection.connect()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 617, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 99 connecting to localhost:6379. Cannot assign requested address.

----------------------------------------------------------------------
Ran 1 test in 1.160s

FAILED (errors=1)
@rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $
```

This PR also includes a fix in `ch01_listing_source.py`.

```sh
@rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $ docker exec -it redis-in-action-python python ch01_listing_source.py
We posted a new article with id: 1

Its HASH looks like:
{b'title': b'A title', b'link': b'http://www.google.com', b'poster': b'username', b'time': b'1680472955.2467878', b'votes': b'1'}

We voted for the article, it now has votes: 2

The currently highest-scoring articles are:
[{b'link': b'http://www.google.com',
  b'poster': b'username',
  b'time': b'1680472955.2467878',
  b'title': b'A title',
  b'votes': b'2',
  'id': b'article:1'}]

We added the article to a new group, other articles include:
[{b'link': b'http://www.google.com',
  b'poster': b'username',
  b'time': b'1680472955.2467878',
  b'title': b'A title',
  b'votes': b'2',
  'id': b'article:1'}]



.
----------------------------------------------------------------------
Ran 1 test in 0.295s

OK
@rilma ➜ /workspaces/redis-in-action/python (issue/96-redis-service-is-never-up) $
```