### PR TITLE
Fixing network configuration and host for executing tests in Docker Compose and Command Line

### DIFF
--- a/golang/config/config.go
+++ b/golang/config/config.go
@@ -2,10 +2,10 @@ package config
 
 // config for redis
 var (
-	Addr     = "redis-in-action-redis:6379"
+	Addr     = "localhost:6379"
 	Password = ""
 	DB       = 15
 )
 
-// file path for Chapter05 
+// file path for Chapter05
 const FilePath = "../Chapter05/GeoLite2-City-CSV_20200121/"

--- a/golang/docker-compose.yml
+++ b/golang/docker-compose.yml
@@ -1,9 +1,5 @@
 version: "3"
 
-networks:
-    my-test:
-        driver: bridge
-
 services: 
     golang:
         build: .
@@ -11,10 +7,9 @@ services:
         tty: true
         volumes:
             - .:/src/app
-        networks:
-            - my-test
         depends_on:
             - redis
+        network_mode: "host"
     
     redis:
         image: redis:6.0-rc-alpine
@@ -23,5 +18,3 @@ services:
           - "6379:6379"
         expose:
           - "6379"
-        networks:
-            - my-test


### PR DESCRIPTION
As part of #98, this PR implements two changes, see commits. We can execute the testing cases using the same host either from Docker Compose or Command Line. Sharing run example for testing cases of Chapter 1 as run in both Docker Compose and Command Line. In addition, I've removed the original network set up in Docker Compose as can be configured in a more simple way as shown in this PR.

```sh
@rilma ➜ /workspaces/redis-in-action/golang (issue/98-failing-test-chp2-and-chp5) $ docker-compose up -d
Creating network "golang_default" with the default driver
Pulling redis (redis:6.0-rc-alpine)...
6.0-rc-alpine: Pulling from library/redis
cbdbe7a5bc2a: Pull complete
dc0373118a0d: Pull complete
cfd369fe6256: Pull complete
09a935bf1649: Pull complete
23985a6095ec: Pull complete
561cada643a7: Pull complete
Digest: sha256:ff868fb1ff9c8b42a23ba1a1a43c5c13a18ba737e1234321d42c55d924e4a057
Status: Downloaded newer image for redis:6.0-rc-alpine
Building golang
[+] Building 3.6s (11/11) FINISHED                                                                                                                                                             
 => [internal] load build definition from Dockerfile                                                                                                                                      0.3s
 => => transferring dockerfile: 35B                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                         0.2s
 => => transferring context: 2B                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/golang:1.14-alpine3.11                                                                                                                 0.9s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                             0.0s
 => [1/5] FROM docker.io/library/golang:1.14-alpine3.11@sha256:4f1c80d88c5879067f063770c774a8ffd4de47b684333cdbe9a4ce661931b9b8                                                           0.0s
 => [internal] load build context                                                                                                                                                         0.2s
 => => transferring context: 4.87kB                                                                                                                                                       0.0s
 => CACHED [2/5] WORKDIR /src/app                                                                                                                                                         0.0s
 => CACHED [3/5] COPY go.mod go.sum ./                                                                                                                                                    0.0s
 => CACHED [4/5] RUN go mod download                                                                                                                                                      0.0s
 => [5/5] COPY . .                                                                                                                                                                        0.4s
 => exporting to image                                                                                                                                                                    1.6s
 => => exporting layers                                                                                                                                                                   1.4s
 => => writing image sha256:89beceb278834bfcdbfdeb666a439360400b54ddf0ff482319799fa80cb5781b                                                                                              0.0s
 => => naming to docker.io/library/golang_golang                                                                                                                                          0.0s
WARNING: Image for service golang was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating redis-in-action-redis ... done
Creating redis-in-action-golang ... done
@rilma ➜ /workspaces/redis-in-action/golang (issue/98-failing-test-chp2-and-chp5) $ docker exec -it redis-in-action-golang go test ./Chapter01/redisConn_test.go -v
=== RUN   Test
    redisConn_test.go:15: We posted a new article with id:  1
    redisConn_test.go:19: 
        Its HASH looks like:  map[link:http://www.google.com poster:username time:1680882408 title:A title votes:1]
    redisConn_test.go:24: 
        We voted for the article, it now has votes:  2
    redisConn_test.go:27: 
        The currently highest-scoring articles are: 
    redisConn_test.go:31: 0 map[id:article:1 link:http://www.google.com poster:username time:1680882408 title:A title votes:2]
    redisConn_test.go:36: 
        We added the article to a new group, other articles include: 
    redisConn_test.go:39: 0 map[id:article:1 link:http://www.google.com poster:username time:1680882408 title:A title votes:2]
--- PASS: Test (0.01s)
PASS
ok      command-line-arguments  0.017s
@rilma ➜ /workspaces/redis-in-action/golang (issue/98-failing-test-chp2-and-chp5) go test ./Chapter01/redisConn_test.go -v
bash: test: ./Chapter01/redisConn_test.go: unary operator expected
@rilma ➜ /workspaces/redis-in-action/golang (issue/98-failing-test-chp2-and-chp5) $ do test ./Chapter01/redisConn_test.go -v
=== RUN   Test
    redisConn_test.go:15: We posted a new article with id:  1
    redisConn_test.go:19: 
        Its HASH looks like:  map[link:http://www.google.com poster:username time:1680882435 title:A title votes:1]
    redisConn_test.go:24: 
        We voted for the article, it now has votes:  2
    redisConn_test.go:27: 
        The currently highest-scoring articles are: 
    redisConn_test.go:31: 0 map[id:article:1 link:http://www.google.com poster:username time:1680882435 title:A title votes:2]
    redisConn_test.go:36: 
        We added the article to a new group, other articles include: 
    redisConn_test.go:39: 0 map[id:article:1 link:http://www.google.com poster:username time:1680882435 title:A title votes:2]
--- PASS: Test (0.01s)
PASS
ok      command-line-arguments  0.010s
@rilma ➜ /workspaces/redis-in-action/golang (issue/98-failing-test-chp2-and-chp5) $
```