### PR TITLE
Document execution of testing in `golang/redisConn` subdirectory

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -15,6 +15,7 @@ Rewrite the code from the amazing book Redis-In-Action using `golang` and `go-re
 - check the config messages in the config/config.go file first, you may need to set your config for redis
 - run `docker-compose up -d` in the directory.
 - use `docker exec -it redis-in-action-golang go test ./Chapter0*/redisConn_test.go -v` to run the test, use number 1 through 8 to replace the `*` depending on the Chapter's examples you want to run.
+- for testing in `redisConn` subdirectory, please use `docker exec -it redis-in-action-golang go test ./redisConn/redisConn_test.go ./redisConn/redisConn.go -v`.
 
 #### Using command-line/terminal: 
 
@@ -24,6 +25,7 @@ Open a command-line/terminal in the `golang` directory and execute follow comman
 
 - `go test ./Chapter0*/redisConn_test.go -v`, use number 1 through 8 to replace the `*`  depending on the Chapter's examples you want to run.
 
+- `go test ./redisConn/redisConn_test.go ./redisConn/redisConn.go -v` executes testing in `redisConn` subdirectory.
 
 ### Todo：
 


### PR DESCRIPTION
This PR improves documentation in `golang/README.md`, specifically for the execution of testing script in `golang/redisConn` subdirectory. No more confusions in the proper execution, this issue #101 must be closed.

```sh
@rilma ➜ /workspaces/redis-in-action/golang (issue/101-bug-in-redisConn-test) $ docker exec -it redis-in-action-golang go test ./redisConn/redisConn_test.go ./redisConn/redisConn.go -v
=== RUN   TestCheckVersion
--- PASS: TestCheckVersion (0.00s)
=== RUN   TestTxPipeline
=== RUN   TestTxPipeline/Tx_Example1:_tx.TxPipeline()
    redisConn_test.go:27: before tx incr key: 1
    redisConn_test.go:29: inside tx incr key: 0
    redisConn_test.go:39: after tx get key: 1
=== RUN   TestTxPipeline/Tx_Example2:_tx.Pipelined()
    redisConn_test.go:47: before tx incr key: 1
    redisConn_test.go:49: inside tx incr key: 0
    redisConn_test.go:58: after tx get key: 1
=== RUN   TestTxPipeline/Tx_a_wrong_example
    redisConn_test.go:68: before tx incr key: 1
    redisConn_test.go:69: inside tx incr key: 0
    redisConn_test.go:80: after tx get key: 2
--- PASS: TestTxPipeline (0.01s)
    --- PASS: TestTxPipeline/Tx_Example1:_tx.TxPipeline() (0.00s)
    --- PASS: TestTxPipeline/Tx_Example2:_tx.Pipelined() (0.00s)
    --- PASS: TestTxPipeline/Tx_a_wrong_example (0.00s)
PASS
ok      command-line-arguments  0.017s
@rilma ➜ /workspaces/redis-in-action/golang (issue/101-bug-in-redisConn-test) $ 
```