### PR TITLE
Issue/95 update java redis library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 /java/build
+/java/.gradle
 GeoLiteCity-*.csv
 .idea
 *.iml

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
 
-    compile 'redis.clients:jedis:2.1.0'
+    compile 'redis.clients:jedis:4.3.2'
     compile 'org.javatuples:javatuples:1.2'
     compile 'com.google.code.gson:gson:2.2.2'
 

--- a/java/src/main/java/Chapter01.java
+++ b/java/src/main/java/Chapter01.java
@@ -13,7 +13,7 @@ public class Chapter01 {
     }
 
     public void run() {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
 
         String articleId = postArticle(

--- a/java/src/main/java/Chapter01.java
+++ b/java/src/main/java/Chapter01.java
@@ -1,5 +1,5 @@
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.ZParams;
 
 import java.util.*;
 

--- a/java/src/main/java/Chapter01.java
+++ b/java/src/main/java/Chapter01.java
@@ -88,7 +88,7 @@ public class Chapter01 {
         int start = (page - 1) * ARTICLES_PER_PAGE;
         int end = start + ARTICLES_PER_PAGE - 1;
 
-        Set<String> ids = conn.zrevrange(order, start, end);
+        List<String> ids = conn.zrevrange(order, start, end);
         List<Map<String,String>> articles = new ArrayList<Map<String,String>>();
         for (String id : ids){
             Map<String,String> articleData = conn.hgetAll(id);

--- a/java/src/main/java/Chapter02.java
+++ b/java/src/main/java/Chapter02.java
@@ -103,7 +103,7 @@ public class Chapter02 {
         System.out.println("First, let's schedule caching of itemX every 5 seconds");
         scheduleRowCache(conn, "itemX", 5);
         System.out.println("Our schedule looks like:");
-        Set<Tuple> s = conn.zrangeWithScores("schedule:", 0, -1);
+        List<Tuple> s = conn.zrangeWithScores("schedule:", 0, -1);
         for (Tuple tuple : s){
             System.out.println("  " + tuple.getElement() + ", " + tuple.getScore());
         }
@@ -285,8 +285,8 @@ public class Chapter02 {
                 }
 
                 long endIndex = Math.min(size - limit, 100);
-                Set<String> tokenSet = conn.zrange("recent:", 0, endIndex - 1);
-                String[] tokens = tokenSet.toArray(new String[tokenSet.size()]);
+                List<String> tokenList = conn.zrange("recent:", 0, endIndex - 1);
+                String[] tokens = tokenList.toArray(new String[tokenList.size()]);
 
                 ArrayList<String> sessionKeys = new ArrayList<String>();
                 for (String token : tokens) {
@@ -330,8 +330,8 @@ public class Chapter02 {
                 }
 
                 long endIndex = Math.min(size - limit, 100);
-                Set<String> sessionSet = conn.zrange("recent:", 0, endIndex - 1);
-                String[] sessions = sessionSet.toArray(new String[sessionSet.size()]);
+                List<String> sessionList = conn.zrange("recent:", 0, endIndex - 1);
+                String[] sessions = sessionList.toArray(new String[sessionList.size()]);
 
                 ArrayList<String> sessionKeys = new ArrayList<String>();
                 for (String sess : sessions) {
@@ -364,7 +364,7 @@ public class Chapter02 {
         public void run() {
             Gson gson = new Gson();
             while (!quit){
-                Set<Tuple> range = conn.zrangeWithScores("schedule:", 0, 0);
+                List<Tuple> range = conn.zrangeWithScores("schedule:", 0, 0);
                 Tuple next = range.size() > 0 ? range.iterator().next() : null;
                 long now = System.currentTimeMillis() / 1000;
                 if (next == null || next.getScore() > now){

--- a/java/src/main/java/Chapter02.java
+++ b/java/src/main/java/Chapter02.java
@@ -1,6 +1,6 @@
 import com.google.gson.Gson;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/java/src/main/java/Chapter02.java
+++ b/java/src/main/java/Chapter02.java
@@ -16,7 +16,7 @@ public class Chapter02 {
     public void run()
         throws InterruptedException
     {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
 
         testLoginCookies(conn);
@@ -263,7 +263,7 @@ public class Chapter02 {
         private boolean quit;
 
         public CleanSessionsThread(int limit) {
-            this.conn = new Jedis("localhost");
+            this.conn = new Jedis("redis://localhost:6379");
             this.conn.select(15);
             this.limit = limit;
         }
@@ -308,7 +308,7 @@ public class Chapter02 {
         private boolean quit;
 
         public CleanFullSessionsThread(int limit) {
-            this.conn = new Jedis("localhost");
+            this.conn = new Jedis("redis://localhost:6379");
             this.conn.select(15);
             this.limit = limit;
         }
@@ -353,7 +353,7 @@ public class Chapter02 {
         private boolean quit;
 
         public CacheRowsThread() {
-            this.conn = new Jedis("localhost");
+            this.conn = new Jedis("redis://localhost:6379");
             this.conn.select(15);
         }
 

--- a/java/src/main/java/Chapter04.java
+++ b/java/src/main/java/Chapter04.java
@@ -201,7 +201,6 @@ public class Chapter04 {
     public void updateTokenPipeline(Jedis conn, String token, String user, String item) {
         long timestamp = System.currentTimeMillis() / 1000;
         Pipeline pipe = conn.pipelined();
-        pipe.multi();
         pipe.hset("login:", token, user);
         pipe.zadd("recent:", timestamp, token);
         if (item != null){
@@ -209,6 +208,6 @@ public class Chapter04 {
             pipe.zremrangeByRank("viewed:" + token, 0, -26);
             pipe.zincrby("viewed:", -1, item);
         }
-        pipe.exec();
+        pipe.sync();
     }
 }

--- a/java/src/main/java/Chapter04.java
+++ b/java/src/main/java/Chapter04.java
@@ -14,7 +14,7 @@ public class Chapter04 {
     }
 
     public void run() {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
 
         testListItem(conn, false);

--- a/java/src/main/java/Chapter04.java
+++ b/java/src/main/java/Chapter04.java
@@ -1,7 +1,7 @@
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Transaction;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import java.lang.reflect.Method;
 import java.util.List;

--- a/java/src/main/java/Chapter04.java
+++ b/java/src/main/java/Chapter04.java
@@ -44,7 +44,7 @@ public class Chapter04 {
         boolean l = listItem(conn, item, seller, 10);
         System.out.println("Listing the item succeeded? " + l);
         assert l;
-        Set<Tuple> r = conn.zrangeWithScores("market:", 0, -1);
+        List<Tuple> r = conn.zrangeWithScores("market:", 0, -1);
         System.out.println("The market contains:");
         for (Tuple tuple : r){
             System.out.println("  " + tuple.getElement() + ", " + tuple.getScore());

--- a/java/src/main/java/Chapter05.java
+++ b/java/src/main/java/Chapter05.java
@@ -40,7 +40,7 @@ public class Chapter05 {
     public void run()
         throws InterruptedException
     {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
 
         testLogRecent(conn);
@@ -422,7 +422,7 @@ public class Chapter05 {
     public Jedis redisConnection(String component){
         Jedis configConn = REDIS_CONNECTIONS.get("config");
         if (configConn == null){
-            configConn = new Jedis("localhost");
+            configConn = new Jedis("redis://localhost:6379");
             configConn.select(15);
             REDIS_CONNECTIONS.put("config", configConn);
         }
@@ -432,7 +432,7 @@ public class Chapter05 {
         Map<String,Object> config = getConfig(configConn, "redis", component);
 
         if (!config.equals(oldConfig)){
-            Jedis conn = new Jedis("localhost");
+            Jedis conn = new Jedis("redis://localhost:6379");
             if (config.containsKey("db")){
                 conn.select(((Double)config.get("db")).intValue());
             }
@@ -542,7 +542,7 @@ public class Chapter05 {
         private long timeOffset; // used to mimic a time in the future.
 
         public CleanCountersThread(int sampleCount, long timeOffset){
-            this.conn = new Jedis("localhost");
+            this.conn = new Jedis("redis://localhost:6379");
             this.conn.select(15);
             this.sampleCount = sampleCount;
             this.timeOffset = timeOffset;

--- a/java/src/main/java/Chapter05.java
+++ b/java/src/main/java/Chapter05.java
@@ -2,7 +2,11 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.csv.CSVParser;
 import org.javatuples.Pair;
-import redis.clients.jedis.*;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.resps.Tuple;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.params.ZParams;
 
 import java.io.File;
 import java.io.FileReader;

--- a/java/src/main/java/Chapter05.java
+++ b/java/src/main/java/Chapter05.java
@@ -78,7 +78,7 @@ public class Chapter05 {
                 logCommon(conn, "test", "message-" + count);
             }
         }
-        Set<Tuple> common = conn.zrevrangeWithScores("common:test:info", 0, -1);
+        List<Tuple> common = conn.zrevrangeWithScores("common:test:info", 0, -1);
         System.out.println("The current number of common messages is: " + common.size());
         System.out.println("Those common messages are:");
         for (Tuple tuple : common){
@@ -153,7 +153,7 @@ public class Chapter05 {
             timer.stop("req-" + i);
         }
         System.out.println("The slowest access times are:");
-        Set<Tuple> atimes = conn.zrevrangeWithScores("slowest:AccessTime", 0, -1);
+        List<Tuple> atimes = conn.zrevrangeWithScores("slowest:AccessTime", 0, -1);
         for (Tuple tuple : atimes){
             System.out.println("  " + tuple.getElement() + ", " + tuple.getScore());
         }
@@ -359,7 +359,7 @@ public class Chapter05 {
     public Map<String,Double> getStats(Jedis conn, String context, String type){
         String key = "stats:" + context + ':' + type;
         Map<String,Double> stats = new HashMap<String,Double>();
-        Set<Tuple> data = conn.zrangeWithScores(key, 0, -1);
+        List<Tuple> data = conn.zrangeWithScores(key, 0, -1);
         for (Tuple tuple : data){
             stats.put(tuple.getElement(), tuple.getScore());
         }
@@ -523,7 +523,7 @@ public class Chapter05 {
 
     public String[] findCityByIp(Jedis conn, String ipAddress) {
         int score = ipToScore(ipAddress);
-        Set<String> results = conn.zrevrangeByScore("ip2cityid:", score, 0, 0, 1);
+        List<String> results = conn.zrevrangeByScore("ip2cityid:", score, 0, 0, 1);
         if (results.size() == 0) {
             return null;
         }
@@ -558,7 +558,7 @@ public class Chapter05 {
                 long start = System.currentTimeMillis() + timeOffset;
                 int index = 0;
                 while (index < conn.zcard("known:")){
-                    Set<String> hashSet = conn.zrange("known:", index, index);
+                    List<String> hashSet = conn.zrange("known:", index, index);
                     index++;
                     if (hashSet.size() == 0) {
                         break;

--- a/java/src/main/java/Chapter06.java
+++ b/java/src/main/java/Chapter06.java
@@ -586,8 +586,7 @@ public class Chapter06 {
 
     @SuppressWarnings("unchecked")
     public List<ChatMessages> fetchPendingMessages(Jedis conn, String recipient) {
-        Set<Tuple> seenSet = conn.zrangeWithScores("seen:" + recipient, 0, -1);
-        List<Tuple> seenList = new ArrayList<Tuple>(seenSet);
+        List<Tuple> seenList = conn.zrangeWithScores("seen:" + recipient, 0, -1);
 
         Transaction trans = conn.multi();
         for (Tuple tuple : seenList){
@@ -628,10 +627,10 @@ public class Chapter06 {
             conn.zadd("chat:" + chatId, seenId, recipient);
             seenUpdates.add(new Object[]{"seen:" + recipient, seenId, chatId});
 
-            Set<Tuple> minIdSet = conn.zrangeWithScores("chat:" + chatId, 0, 0);
-            if (minIdSet.size() > 0){
+            List<Tuple> minIdList = conn.zrangeWithScores("chat:" + chatId, 0, 0);
+            if (minIdList.size() > 0){
                 msgRemoves.add(new Object[]{
-                    "msgs:" + chatId, minIdSet.iterator().next().getScore()});
+                    "msgs:" + chatId, minIdList.iterator().next().getScore()});
             }
             chatMessages.add(new ChatMessages(chatId, messages));
         }
@@ -789,7 +788,7 @@ public class Chapter06 {
 
         public void run() {
             while (!quit){
-                Set<Tuple> items = conn.zrangeWithScores("delayed:", 0, 0);
+                List<Tuple> items = conn.zrangeWithScores("delayed:", 0, 0);
                 Tuple item = items.size() > 0 ? items.iterator().next() : null;
                 if (item == null || item.getScore() > System.currentTimeMillis()) {
                     try{

--- a/java/src/main/java/Chapter06.java
+++ b/java/src/main/java/Chapter06.java
@@ -2,8 +2,8 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Transaction;
-import redis.clients.jedis.Tuple;
-import redis.clients.jedis.ZParams;
+import redis.clients.jedis.resps.Tuple;
+import redis.clients.jedis.params.ZParams;
 
 import java.io.*;
 import java.util.*;

--- a/java/src/main/java/Chapter06.java
+++ b/java/src/main/java/Chapter06.java
@@ -20,7 +20,7 @@ public class Chapter06 {
     public void run()
         throws InterruptedException, IOException
     {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
 
         testAddUpdateContact(conn);
@@ -778,7 +778,7 @@ public class Chapter06 {
         private Gson gson = new Gson();
 
         public PollQueueThread(){
-            this.conn = new Jedis("localhost");
+            this.conn = new Jedis("redis://localhost:6379");
             this.conn.select(15);
         }
 
@@ -828,7 +828,7 @@ public class Chapter06 {
         private long limit;
 
         public CopyLogsThread(File path, String channel, int count, long limit) {
-            this.conn = new Jedis("localhost");
+            this.conn = new Jedis("redis://localhost:6379");
             this.conn.select(15);
             this.path = path;
             this.channel = channel;

--- a/java/src/main/java/Chapter07.java
+++ b/java/src/main/java/Chapter07.java
@@ -885,7 +885,7 @@ public class Chapter07 {
         trans.exec();
     }
 
-    public Set<String> findJobs(Jedis conn, String... candidateSkills) {
+    public List<String> findJobs(Jedis conn, String... candidateSkills) {
         String[] keys = new String[candidateSkills.length];
         int[] weights = new int[candidateSkills.length];
         for (int i = 0; i < candidateSkills.length; i++) {

--- a/java/src/main/java/Chapter07.java
+++ b/java/src/main/java/Chapter07.java
@@ -1,5 +1,9 @@
 import org.javatuples.Pair;
-import redis.clients.jedis.*;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.resps.Tuple;
+import redis.clients.jedis.params.ZParams;
+import redis.clients.jedis.params.SortingParams;
 
 import java.util.*;
 import java.util.regex.Matcher;

--- a/java/src/main/java/Chapter07.java
+++ b/java/src/main/java/Chapter07.java
@@ -42,7 +42,7 @@ public class Chapter07 {
     }
 
     public void run(){
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
         conn.flushDB();
 
@@ -360,7 +360,7 @@ public class Chapter07 {
 
         String id = UUID.randomUUID().toString();
         try{
-            trans.getClass()
+            trans.getClass().getSuperclass()
                 .getDeclaredMethod(method, String.class, String[].class)
                 .invoke(trans, "idx:" + id, keys);
         }catch(Exception e){
@@ -392,7 +392,7 @@ public class Chapter07 {
 
         String id = UUID.randomUUID().toString();
         try{
-            trans.getClass()
+            trans.getClass().getSuperclass()
                 .getDeclaredMethod(method, String.class, ZParams.class, String[].class)
                 .invoke(trans, "idx:" + id, params, keys);
         }catch(Exception e){
@@ -547,7 +547,7 @@ public class Chapter07 {
             id,
             ((Long)results.get(results.size() - 2)).longValue(),
             // Note: it's a LinkedHashSet, so it's ordered
-            new ArrayList<String>((Set<String>)results.get(results.size() - 1)));
+                (List<String>)results.get(results.size() - 1));
     }
 
     public long stringToScore(String string) {
@@ -596,7 +596,7 @@ public class Chapter07 {
     }
 
     public long zaddString(Jedis conn, String name, Map<String,String> values) {
-        Map<String,Double> pieces = new HashMap<String,Double>(values.size());
+            Map<String,Double> pieces = new HashMap<String,Double>(values.size());
         for (Map.Entry<String,String> entry : values.entrySet()) {
             pieces.put(entry.getKey(), (double)stringToScore(entry.getValue()));
         }
@@ -663,7 +663,7 @@ public class Chapter07 {
 
         List<Object> response = trans.exec();
         long targetId = (Long)response.get(response.size() - 2);
-        Set<String> targetedAds = (Set<String>)response.get(response.size() - 1);
+        List<String> targetedAds = (List<String>)response.get(response.size() - 1);
 
         if (targetedAds.size() == 0){
             return new Pair<Long,String>(null, null);

--- a/java/src/main/java/Chapter07.java
+++ b/java/src/main/java/Chapter07.java
@@ -596,9 +596,9 @@ public class Chapter07 {
     }
 
     public long zaddString(Jedis conn, String name, Map<String,String> values) {
-        Map<Double,String> pieces = new HashMap<Double,String>(values.size());
+        Map<String,Double> pieces = new HashMap<String,Double>(values.size());
         for (Map.Entry<String,String> entry : values.entrySet()) {
-            pieces.put((double)stringToScore(entry.getValue()), entry.getKey());
+            pieces.put(entry.getKey(), (double)stringToScore(entry.getValue()));
         }
 
         return conn.zadd(name, pieces);
@@ -697,7 +697,7 @@ public class Chapter07 {
         if (bonusEcpm.size() > 0){
 
             String[] keys = new String[bonusEcpm.size()];
-            int[] weights = new int[bonusEcpm.size()];
+            double[] weights = new double[bonusEcpm.size()];
             int index = 0;
             for (Map.Entry<String,Integer> bonus : bonusEcpm.entrySet()){
                 keys[index] = bonus.getKey();
@@ -887,7 +887,7 @@ public class Chapter07 {
 
     public List<String> findJobs(Jedis conn, String... candidateSkills) {
         String[] keys = new String[candidateSkills.length];
-        int[] weights = new int[candidateSkills.length];
+        double[] weights = new double[candidateSkills.length];
         for (int i = 0; i < candidateSkills.length; i++) {
             keys[i] = "skill:" + candidateSkills[i];
             weights[i] = 1;

--- a/java/src/main/java/Chapter08.java
+++ b/java/src/main/java/Chapter08.java
@@ -20,7 +20,7 @@ public class Chapter08 {
     public void run()
         throws InterruptedException
     {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
         conn.flushDB();
 
@@ -239,7 +239,7 @@ public class Chapter08 {
         List<Object> response = trans.exec();
         long following = (Long)response.get(response.size() - 3);
         long followers = (Long)response.get(response.size() - 2);
-        Set<Tuple> statuses = (Set<Tuple>)response.get(response.size() - 1);
+        List<Tuple> statuses = (ArrayList<Tuple>)response.get(response.size() - 1);
 
         trans = conn.multi();
         trans.hset("user:" + uid, "following", String.valueOf(following));
@@ -538,7 +538,7 @@ public class Chapter08 {
         }
 
         public void run() {
-            Jedis conn = new Jedis("localhost");
+            Jedis conn = new Jedis("redis://localhost:6379");
             conn.select(15);
 
             Object[] args = new Object[this.args.length + 1];

--- a/java/src/main/java/Chapter08.java
+++ b/java/src/main/java/Chapter08.java
@@ -349,7 +349,7 @@ public class Chapter08 {
     public void syndicateStatus(
         Jedis conn, long uid, long postId, long postTime, double start)
     {
-        Set<Tuple> followers = conn.zrangeByScoreWithScores(
+        List<Tuple> followers = conn.zrangeByScoreWithScores(
             "followers:" + uid,
             String.valueOf(start), "inf",
             0, POSTS_PER_PASS);
@@ -409,7 +409,7 @@ public class Chapter08 {
     public List<Map<String,String>> getStatusMessages(
         Jedis conn, long uid, int page, int count)
     {
-        Set<String> statusIds = conn.zrevrange(
+        List<String> statusIds = conn.zrevrange(
             "home:" + uid, (page - 1) * count, page * count - 1);
 
         Transaction trans = conn.multi();
@@ -439,7 +439,7 @@ public class Chapter08 {
             return;
         }
 
-        Set<Tuple> users = conn.zrangeByScoreWithScores(
+        List<Tuple> users = conn.zrangeByScoreWithScores(
             incoming, String.valueOf(start), "inf", 0, REFILL_USERS_STEP);
 
         Pipeline pipeline = conn.pipelined();
@@ -491,7 +491,7 @@ public class Chapter08 {
             key = "list:out:" + uid;
             base = "list:statuses:";
         }
-        Set<Tuple> followers = conn.zrangeByScoreWithScores(
+        List<Tuple> followers = conn.zrangeByScoreWithScores(
             key, String.valueOf(start), "inf", 0, POSTS_PER_PASS);
 
         Transaction trans = conn.multi();

--- a/java/src/main/java/Chapter08.java
+++ b/java/src/main/java/Chapter08.java
@@ -1,7 +1,7 @@
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Transaction;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import java.lang.reflect.Method;
 import java.util.*;

--- a/java/src/main/java/Chapter09.java
+++ b/java/src/main/java/Chapter09.java
@@ -1,7 +1,7 @@
 import org.javatuples.Pair;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.ZParams;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/java/src/main/java/Chapter09.java
+++ b/java/src/main/java/Chapter09.java
@@ -46,7 +46,7 @@ public class Chapter09 {
     }
 
     public void run() {
-        Jedis conn = new Jedis("localhost");
+        Jedis conn = new Jedis("redis://localhost:6379");
         conn.select(15);
         conn.flushDB();
 


### PR DESCRIPTION
#### update jedis latest stable version 4.3.2

The PR contains only the minimal changes required to compile and run the examples with the latest stable jedis version.

#### moved classes
* Tuple
* ZParams

#### method parameter/return types changed
* Jedis.zrangeWithScores
* Jedis.zrevrangeWithScores
* Jedis.zrevrange
* Jedis.zadd
* ZParams.weights

#### fix reflection usage
* reflection code was broken because methods were moved from Transaction to TransactionBase

#### Jedis constructor requires a valid redis uri e.g. `redis://<host>:<port>`

#### Remark
I tested examples for all chapters. Everything works except chapter 8. But it turns out that this does not work in master either.
A separate issue was created for that: https://github.com/josiahcarlson/redis-in-action/issues/103