### PR TITLE
Java chapter 10 and 11 examples

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -24,4 +24,6 @@ dependencies {
 //set the main class from the command line property 'mainClass' (e.g. gradle -PmainClass=Chapter02)
 def chapterPrefix = 'Chapter0'
 def defaultChapter = '1'
-mainClassName = chapterPrefix + (project.hasProperty('chapter') ? chapter  : defaultChapter)
+def ch = (project.hasProperty('chapter') ? chapter : defaultChapter).toString()
+mainClassName = (ch.toInteger() < 10 ? 'Chapter0' : 'Chapter') + ch
+

--- a/java/src/main/java/Chapter10.java
+++ b/java/src/main/java/Chapter10.java
@@ -1,0 +1,1399 @@
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.javatuples.Pair;
+import redis.clients.jedis.*;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+
+public class Chapter10 {
+
+    private static final ConcurrentHashMap<String, Map<String, Object>> CONFIGS =
+            new ConcurrentHashMap<String, Map<String, Object>>();
+    private static final ConcurrentHashMap<String, JedisPool> REDIS_CONNECTIONS =
+            new ConcurrentHashMap<String, JedisPool>();
+    private static final ConcurrentHashMap<String, Long> CHECKED_MS =
+            new ConcurrentHashMap<String, Long>();
+    private static volatile JedisPool configConnection;
+
+    private static final Gson GSON = new Gson();
+    private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {
+    }.getType();
+
+    private static final ConcurrentHashMap<String, Long> EXPECTED =
+            new ConcurrentHashMap<String, Long>();
+
+    private static final int SHARD_SIZE = 512;
+    private static final int DELAY_EXPECTED = 1000000;
+
+    private static final SimpleDateFormat ISO_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:00:00");
+
+    private static final int HOME_TIMELINE_SIZE = 1000;
+    private static final int POSTS_PER_PASS = 1000;
+
+    private static final int SHARDED_TIMELINES_SHARDS = 8;
+    private static final int SHARDED_FOLLOWERS_SHARDS = 16;
+
+    static {
+        ISO_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    private static final Pattern QUERY_RE = Pattern.compile("[+-]?[a-z']{2,}");
+
+    private static final Set<String> STOP_WORDS = new HashSet<String>();
+
+    static {
+        Collections.addAll(STOP_WORDS, ("able about across after all almost also am among " +
+                "an and any are as at be because been but by can " +
+                "cannot could dear did do does either else ever " +
+                "every for from get got had has have he her hers " +
+                "him his how however if in into is it its just " +
+                "least let like likely may me might most must my " +
+                "neither no nor not of off often on only or other " +
+                "our own rather said say says she should since so " +
+                "some than that the their them then there these " +
+                "they this tis to too twas us wants was we were " +
+                "what when where which while who whom why will " +
+                "with would yet you your").split(" "));
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        new Chapter10().run();
+    }
+
+    public void run() throws Exception {
+        Jedis conn = new Jedis("localhost");
+        conn.select(15);
+
+        conn.flushDB();
+
+        seedRedisConfigs(conn);
+
+        JedisPool configPool = new JedisPool(new JedisPoolConfig(), "127.0.0.1", 6379, 2000, null, 15);
+        Chapter10.setConfigConnection(configPool);
+
+        Chapter10 ch10 = new Chapter10();
+
+        testCountVisit(conn);
+        testSearchAndSort(conn, ch10);
+        testFollowUser(conn, ch10);
+        testDelayedTasks(conn, ch10);
+
+        System.out.println("\nALL TESTS DONE.");
+    }
+
+    private void seedRedisConfigs(Jedis conn) {
+        System.out.println("\n----- seedRedisConfigs -----");
+
+        String json = "{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":15,\"timeoutMillis\":2000}";
+
+        conn.set("config:redis:default", json);
+        conn.set("config:redis:unique", json);
+
+        for (int i = 0; i < 16; i++) {
+            conn.set("config:redis:unique:" + i, json);
+        }
+
+        for (int i = 0; i < 8; i++) {
+            conn.set("config:redis:timelines:" + i, json);
+        }
+
+        for (int i = 0; i < 16; i++) {
+            conn.set("config:redis:followers:" + i, json);
+        }
+
+        for (int i = 0; i < 16; i++) {
+            conn.set("config:redis:list:out:" + i, json);
+        }
+
+        System.out.println("seed done.");
+    }
+
+    public void testCountVisit(Jedis conn) {
+        System.out.println("\n----- testCountVisit -----");
+
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:00:00");
+        fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String key = "unique:" + fmt.format(new Date());
+
+        conn.del(key);
+
+        String sessionId = UUID.randomUUID().toString();
+        Chapter10.countVisit(sessionId);
+
+        String v = conn.get(key);
+        System.out.println("unique key: " + key + " => " + v);
+        assert v != null && Long.parseLong(v) >= 1L;
+    }
+
+    public void testSearchAndSort(Jedis conn, Chapter10 ch10) {
+        System.out.println("\n----- testSearchAndSort -----");
+
+        conn.del("idx:foo");
+        conn.del("kb:doc:1", "kb:doc:2", "kb:doc:3");
+
+        conn.hset("kb:doc:1", "updated", "100");
+        conn.hset("kb:doc:1", "title", "b-title");
+
+        conn.hset("kb:doc:2", "updated", "300");
+        conn.hset("kb:doc:2", "title", "a-title");
+
+        conn.hset("kb:doc:3", "updated", "200");
+        conn.hset("kb:doc:3", "title", "c-title");
+
+        conn.sadd("idx:foo", "1", "2", "3");
+
+        Chapter10.SearchResult r1 = ch10.searchAndSort(conn, "foo", "updated");
+        System.out.println("sort=updated => " + r1.docids);
+        assert r1.docids.size() == 3;
+        assert "1".equals(r1.docids.get(0));
+        assert "3".equals(r1.docids.get(1));
+        assert "2".equals(r1.docids.get(2));
+
+        Chapter10.SearchResult r2 = ch10.searchAndSort(conn, "foo", "title");
+        System.out.println("sort=title => " + r2.docids);
+        assert r2.docids.size() == 3;
+        assert "2".equals(r2.docids.get(0));
+        assert "1".equals(r2.docids.get(1));
+        assert "3".equals(r2.docids.get(2));
+
+        Chapter10.SearchResult r3 = ch10.searchAndSort(conn, "foo", "-updated");
+        System.out.println("sort=-updated => " + r3.docids);
+        assert r3.docids.size() == 3;
+        assert "2".equals(r3.docids.get(0));
+        assert "3".equals(r3.docids.get(1));
+        assert "1".equals(r3.docids.get(2));
+    }
+
+    public void testFollowUser(Jedis conn, Chapter10 ch10) {
+        System.out.println("\n----- testFollowUser -----");
+
+        long uid = 1001L;
+        long otherUid = 2002L;
+
+        conn.del("following:" + uid);
+        conn.del("followers:" + otherUid);
+        conn.del("user:" + uid);
+        conn.del("user:" + otherUid);
+
+        String pkey = "profile:" + otherUid;
+        String hkey = "home:" + uid;
+        conn.del(pkey);
+        conn.del(hkey);
+
+        double now = System.currentTimeMillis() / 1000.0;
+        conn.zadd(pkey, now - 10, "status:1");
+        conn.zadd(pkey, now - 5, "status:2");
+
+        boolean ok = ch10.followUser(conn, uid, otherUid);
+        System.out.println("followUser => " + ok);
+        assert ok;
+
+        Set<Tuple> home = conn.zrevrangeWithScores(hkey, 0, -1);
+        System.out.println("home timeline => " + tuplesToElements(home));
+        assert home != null && home.size() >= 2;
+
+        List<String> elems = tuplesToElements(home);
+        assert elems.contains("status:1");
+        assert elems.contains("status:2");
+    }
+
+    public void testDelayedTasks(Jedis conn, Chapter10 ch10) throws Exception {
+        System.out.println("\n----- testDelayedTasks -----");
+
+        conn.del("delayed:");
+        conn.del("queue:default");
+
+        Chapter10.PollQueueThread t = ch10.new PollQueueThread();
+        t.start();
+
+        List<String> args = new ArrayList<String>();
+        args.add("hello");
+        String id = ch10.executeLater(conn, "default", "test_task", args, 200);
+        System.out.println("scheduled id => " + id);
+
+        Thread.sleep(800);
+
+        long qlen = conn.llen("queue:default");
+        System.out.println("queue:default len => " + qlen);
+        assert qlen >= 1;
+
+        t.quitThread();
+        t.join(1000);
+    }
+
+    private List<String> tuplesToElements(Set<Tuple> tuples) {
+        List<String> out = new ArrayList<String>();
+        if (tuples == null) return out;
+        for (Tuple t : tuples) {
+            out.add(t.getElement());
+        }
+        return out;
+    }
+
+
+    private static void returnJedis(JedisPool pool, Jedis jedis) {
+        if (pool != null && jedis != null) {
+            pool.returnResource(jedis);
+        }
+    }
+
+    private static void returnBrokenJedis(JedisPool pool, Jedis jedis) {
+        if (pool != null && jedis != null) {
+            pool.returnBrokenResource(jedis);
+        }
+    }
+
+    private static boolean eq(Object a, Object b) {
+        return a == b || (a != null && a.equals(b));
+    }
+
+    private static long getOrDefaultLong(Map<String, Long> map, String key, long def) {
+        Long v = map.get(key);
+        return v != null ? v.longValue() : def;
+    }
+
+    public static void setConfigConnection(JedisPool configConn) {
+        configConnection = configConn;
+    }
+
+    public static Map<String, Object> getConfig(JedisPool conn, String type, String component, int wait) {
+        String key = "config:" + type + ":" + component;
+        long now = System.currentTimeMillis();
+        long waitMillis = Math.max(0, wait) * 1000L;
+
+        long lastChecked = getOrDefaultLong(CHECKED_MS, key, 0L);
+        if (lastChecked < now - waitMillis) {
+            CHECKED_MS.put(key, Long.valueOf(now));
+
+            String json = null;
+            Jedis jedis = null;
+            boolean ok = true;
+            try {
+                jedis = conn.getResource();
+                json = jedis.get(key);
+            } catch (Exception e) {
+                ok = false;
+                if (jedis != null) returnBrokenJedis(conn, jedis);
+                throw new RuntimeException(e);
+            } finally {
+                if (ok && jedis != null) returnJedis(conn, jedis);
+            }
+
+            if (json == null || json.trim().length() == 0) {
+                json = "{}";
+            }
+
+            Map<String, Object> config = parseJsonToMap(json);
+            Map<String, Object> oldConfig = CONFIGS.get(key);
+            if (!eq(config, oldConfig)) {
+                CONFIGS.put(key, config);
+            }
+        }
+        return CONFIGS.get(key);
+    }
+
+    private static Map<String, Object> parseJsonToMap(String json) {
+        Map<String, Object> map = (Map<String, Object>) GSON.fromJson(json, MAP_TYPE);
+        return (map == null) ? Collections.<String, Object>emptyMap() : map;
+    }
+
+    public static String shardKey(String base, String key, long totalElements, int shardSize) {
+        long shardId;
+        if (isDigit(key)) {
+            shardId = Integer.parseInt(key, 10) / shardSize;
+        } else {
+            CRC32 crc32 = new CRC32();
+            crc32.update(key.getBytes());
+            long shards = 2 * totalElements / shardSize;
+            shardId = Math.abs(((int) crc32.getValue()) % (int) shards);
+        }
+        return base + ":" + shardId;
+    }
+
+    public static boolean isDigit(String str) {
+        if (str == null || str.length() == 0) return false;
+        for (int i = 0; i < str.length(); i++) {
+            if (!Character.isDigit(str.charAt(i))) return false;
+        }
+        return true;
+    }
+
+    public static JedisPool getRedisConnection(String component, int wait) {
+        String key = "config:redis:" + component;
+        Map<String, Object> oldConfig = CONFIGS.get(key);
+        Map<String, Object> config = getConfig(configConnection, "redis", component, wait);
+        if (config == null) config = Collections.<String, Object>emptyMap();
+
+        if (!eq(config, oldConfig)) {
+            CONFIGS.put(key, config);
+            JedisPool newConn = createJedisPoolFromConfig(config);
+            REDIS_CONNECTIONS.put(key, newConn);
+        }
+        return REDIS_CONNECTIONS.get(key);
+    }
+
+    public static JedisPool getShardedConnection(String component, String key, long shardCount, int wait) {
+        String shard = shardKey(component, "x" + String.valueOf(key), shardCount, 2);
+        return getRedisConnection(shard, wait);
+    }
+
+    public interface ShardedFunction<T> {
+        T call(JedisPool conn, String key, Object... args);
+    }
+
+    public interface ShardedCaller<T> {
+        T call(String key, Object... args);
+    }
+
+    public static <T> ShardedCaller<T> shardedConnection(
+            final String component,
+            final long shardCount,
+            final int wait,
+            final ShardedFunction<T> function) {
+
+        return new ShardedCaller<T>() {
+            public T call(String key, Object... args) {
+                JedisPool conn = getShardedConnection(component, key, shardCount, wait);
+                return function.call(conn, key, args);
+            }
+        };
+    }
+
+    public static long getExpected(Jedis conn, String key, Calendar today) {
+        if (!EXPECTED.containsKey(key)) {
+            String exkey = key + ":expected";
+            String expectedStr = conn.get(exkey);
+
+            long expected;
+            if (expectedStr == null) {
+                Calendar yesterday = (Calendar) today.clone();
+                yesterday.add(Calendar.DATE, -1);
+
+                expectedStr = conn.get("unique:" + ISO_FORMAT.format(yesterday.getTime()));
+                expected = (expectedStr != null) ? Long.parseLong(expectedStr) : (long) DELAY_EXPECTED;
+
+                expected = (long) Math.pow(2, (long) (Math.ceil(Math.log(expected * 1.5) / Math.log(2))));
+                if (conn.setnx(exkey, String.valueOf(expected)) == 0) {
+                    expectedStr = conn.get(exkey);
+                    expected = Long.parseLong(expectedStr);
+                }
+            } else {
+                expected = Long.parseLong(expectedStr);
+            }
+            EXPECTED.put(key, Long.valueOf(expected));
+        }
+        Long v = EXPECTED.get(key);
+        return v != null ? v.longValue() : 0L;
+    }
+
+    public static Pair<JedisPool, Long> getExpected(String key, Calendar today) {
+        JedisPool pool = getRedisConnection("unique", 1);
+        Jedis jedis = null;
+        boolean ok = true;
+        try {
+            jedis = pool.getResource();
+            long expected = getExpected(jedis, key, today);
+            return Pair.with(pool, Long.valueOf(expected));
+        } catch (Exception e) {
+            ok = false;
+            if (jedis != null) returnBrokenJedis(pool, jedis);
+            throw new RuntimeException(e);
+        } finally {
+            if (ok && jedis != null) returnJedis(pool, jedis);
+        }
+    }
+
+    public static final ShardedCaller<Void> COUNT_VISIT =
+            shardedConnection("unique", 16, 1, new ShardedFunction<Void>() {
+                public Void call(JedisPool pool, String sessionId, Object... args) {
+                    Calendar today = Calendar.getInstance();
+                    String key = "unique:" + ISO_FORMAT.format(today.getTime());
+
+                    Pair<JedisPool, Long> p = getExpected(key, today);
+                    JedisPool conn2 = p.getValue0();
+                    long expected = p.getValue1().longValue();
+
+                    long id = Long.parseLong(sessionId.replace("-", "").substring(0, 15), 16);
+
+                    Jedis jedis = null;
+                    boolean ok = true;
+                    boolean added;
+                    try {
+                        jedis = pool.getResource();
+                        added = (shardSadd(jedis, key, id, expected, SHARD_SIZE).longValue() == 1L);
+                    } catch (Exception e) {
+                        ok = false;
+                        if (jedis != null) returnBrokenJedis(pool, jedis);
+                        throw new RuntimeException(e);
+                    } finally {
+                        if (ok && jedis != null) returnJedis(pool, jedis);
+                    }
+
+                    if (added) {
+                        Jedis jedis2 = null;
+                        boolean ok2 = true;
+                        try {
+                            jedis2 = conn2.getResource();
+                            jedis2.incr(key);
+                        } catch (Exception e) {
+                            ok2 = false;
+                            if (jedis2 != null) returnBrokenJedis(conn2, jedis2);
+                            throw new RuntimeException(e);
+                        } finally {
+                            if (ok2 && jedis2 != null) returnJedis(conn2, jedis2);
+                        }
+                    }
+                    return null;
+                }
+            });
+
+    public static void countVisit(String sessionId) {
+        COUNT_VISIT.call(sessionId, new Object[0]);
+    }
+
+    public static Long shardSadd(Jedis conn, String base, long member, long totalElements, int shardSize) {
+        String shard = shardKey(base, "x" + String.valueOf(member), totalElements, shardSize);
+        return conn.sadd(shard, String.valueOf(member));
+    }
+
+    public static final class Query {
+        public final List<List<String>> all = new ArrayList<List<String>>();
+        public final Set<String> unwanted = new HashSet<String>();
+    }
+
+    private String setCommon(Transaction trans, String method, int ttl, String... items) {
+        String[] keys = new String[items.length];
+        for (int i = 0; i < items.length; i++) {
+            keys[i] = "idx:" + items[i];
+        }
+
+        String id = UUID.randomUUID().toString();
+        try {
+            trans.getClass()
+                    .getDeclaredMethod(method, String.class, String[].class)
+                    .invoke(trans, new Object[]{"idx:" + id, keys});
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        trans.expire("idx:" + id, ttl);
+        return id;
+    }
+
+    public String intersect(Transaction trans, int ttl, String... items) {
+        return setCommon(trans, "sinterstore", ttl, items);
+    }
+
+    public String union(Transaction trans, int ttl, String... items) {
+        return setCommon(trans, "sunionstore", ttl, items);
+    }
+
+    public String difference(Transaction trans, int ttl, String... items) {
+        return setCommon(trans, "sdiffstore", ttl, items);
+    }
+
+    public Query parse(String queryStringString) {
+        Query queryString = new Query();
+        Set<String> current = new HashSet<String>();
+
+        Matcher matcher = QUERY_RE.matcher(queryStringString.toLowerCase());
+        while (matcher.find()) {
+            String word = matcher.group().trim();
+            char prefix = word.charAt(0);
+
+            if (prefix == '+' || prefix == '-') {
+                word = word.substring(1);
+            }
+
+            if (word.length() < 2 || STOP_WORDS.contains(word)) {
+                continue;
+            }
+
+            if (prefix == '-') {
+                queryString.unwanted.add(word);
+                continue;
+            }
+
+            if (!current.isEmpty() && prefix != '+') {
+                queryString.all.add(new ArrayList<String>(current));
+                current.clear();
+            }
+            current.add(word);
+        }
+
+        if (!current.isEmpty()) {
+            queryString.all.add(new ArrayList<String>(current));
+        }
+        return queryString;
+    }
+
+    public String parseAndSearch(Jedis conn, String queryStringString, int ttl) {
+        Query queryString = parse(queryStringString);
+        if (queryString.all.isEmpty()) return null;
+
+        List<String> toIntersect = new ArrayList<String>();
+        for (List<String> syn : queryString.all) {
+            if (syn.size() > 1) {
+                Transaction trans = conn.multi();
+                toIntersect.add(union(trans, ttl, syn.toArray(new String[syn.size()])));
+                trans.exec();
+            } else {
+                toIntersect.add(syn.get(0));
+            }
+        }
+
+        String intersectResult;
+        if (toIntersect.size() > 1) {
+            Transaction trans = conn.multi();
+            intersectResult = intersect(trans, ttl, toIntersect.toArray(new String[toIntersect.size()]));
+            trans.exec();
+        } else {
+            intersectResult = toIntersect.get(0);
+        }
+
+        if (!queryString.unwanted.isEmpty()) {
+            String[] keys = queryString.unwanted.toArray(new String[queryString.unwanted.size() + 1]);
+            keys[keys.length - 1] = intersectResult;
+            Transaction trans = conn.multi();
+            intersectResult = difference(trans, ttl, keys);
+            trans.exec();
+        }
+
+        return intersectResult;
+    }
+
+    public SearchResult searchAndSort(Jedis conn, String queryStringString, String sort) {
+        return searchAndSort(conn, queryStringString, null, 300, sort, 0, 20);
+    }
+
+    public SearchResult searchAndSort(Jedis conn, String queryStringString, String id, int ttl, String sort, int start, int num) {
+        boolean desc = sort.startsWith("-");
+        if (desc) sort = sort.substring(1);
+
+        boolean alpha = !("updated".equals(sort) || "id".equals(sort) || "created".equals(sort));
+        String by = "kb:doc:*->" + sort;
+
+        String rid = (id != null) ? id : parseAndSearch(conn, queryStringString, ttl);
+        if (rid == null) {
+            return new SearchResult(null, 0L, Collections.<String>emptyList());
+        }
+
+        conn.expire("idx:" + rid, ttl);
+
+        Transaction trans = conn.multi();
+        trans.scard("idx:" + rid);
+
+        SortingParams params = new SortingParams();
+        if (desc) params.desc();
+        if (alpha) params.alpha();
+        params.by(by);
+        params.limit(start, num);
+
+        trans.sort("idx:" + rid, params);
+
+        List<Object> results = trans.exec();
+        long count = ((Long) results.get(0)).longValue();
+
+        @SuppressWarnings("unchecked")
+        List<String> docids = (List<String>) results.get(1);
+
+        return new SearchResult(rid, count, docids);
+    }
+
+    public SearchGetValuesResult searchGetValues(Jedis conn, String queryString, String id, int ttl, String sort, int start, int num) {
+        SearchResult searchResult = searchAndSort(conn, queryString, id, ttl, sort, 0, start + num);
+        String keyPattern = "kb:doc:%s";
+        String sortField = sort.startsWith("-") ? sort.substring(1) : sort;
+
+        Pipeline pipe = conn.pipelined();
+        for (String docid : searchResult.docids) {
+            pipe.hget(String.format(keyPattern, docid), sortField);
+        }
+
+        List<Object> result = pipe.syncAndReturnAll();
+        List<Pair<String, String>> dataPairs = new ArrayList<Pair<String, String>>(searchResult.docids.size());
+
+        for (int i = 0; i < searchResult.docids.size(); i++) {
+            String docid = searchResult.docids.get(i);
+            Object value = (i < result.size()) ? result.get(i) : null;
+            String col = (value == null) ? null : String.valueOf(value);
+            dataPairs.add(Pair.with(docid, col));
+        }
+
+        return new SearchGetValuesResult(searchResult.count, dataPairs, searchResult.id);
+    }
+
+    public ShardResults getShardResults(String component, int shards, String queryString, List<String> ids, int ttl, String sort, int start, int num, int wait) {
+        long count = 0;
+        List<Pair<String, String>> data = new ArrayList<Pair<String, String>>();
+
+        if (ids == null) {
+            ids = new ArrayList<String>(shards);
+            for (int i = 0; i < shards; i++) ids.add(null);
+        }
+
+        for (int shard = 0; shard < shards; shard++) {
+            JedisPool pool = getRedisConnection(component + ":" + shard, wait);
+            Jedis conn = null;
+            boolean ok = true;
+            try {
+                conn = pool.getResource();
+                SearchGetValuesResult result = searchGetValues(conn, queryString, ids.get(shard), ttl, sort, start, num);
+                count += result.count;
+                data.addAll(result.dataPairs);
+                ids.set(shard, result.id);
+            } catch (Exception e) {
+                ok = false;
+                if (conn != null) returnBrokenJedis(pool, conn);
+                throw new RuntimeException(e);
+            } finally {
+                if (ok && conn != null) returnJedis(pool, conn);
+            }
+        }
+        return new ShardResults(count, data, ids);
+    }
+
+    private static BigDecimal toNumericKey(Pair<String, String> data) {
+        try {
+            String s = data.getValue1();
+            if (s == null || s.length() == 0) return BigDecimal.ZERO;
+            return new BigDecimal(s);
+        } catch (Exception e) {
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private static String toStringKey(Pair<String, String> data) {
+        String s = data.getValue1();
+        return (s == null) ? "" : s;
+    }
+
+    public SearchShardsResult searchShards(String component, int shards, String queryString, List<String> ids, int ttl, String sort, int start, int num, int wait) {
+        ShardResults shardResults = getShardResults(component, shards, queryString, ids, ttl, sort, start, num, wait);
+
+        final boolean reversed = sort.startsWith("-");
+        String sortField = sort.replace("-", "");
+
+        Comparator<Pair<String, String>> comparator;
+        if ("updated".equals(sortField) || "id".equals(sortField) || "created".equals(sortField)) {
+            comparator = new Comparator<Pair<String, String>>() {
+                public int compare(Pair<String, String> o1, Pair<String, String> o2) {
+                    return toNumericKey(o1).compareTo(toNumericKey(o2));
+                }
+            };
+        } else {
+            comparator = new Comparator<Pair<String, String>>() {
+                public int compare(Pair<String, String> o1, Pair<String, String> o2) {
+                    return toStringKey(o1).compareTo(toStringKey(o2));
+                }
+            };
+        }
+
+        if (reversed) {
+            Collections.sort(shardResults.data, Collections.reverseOrder(comparator));
+        } else {
+            Collections.sort(shardResults.data, comparator);
+        }
+
+        List<String> results = new ArrayList<String>();
+        int end = Math.min(shardResults.data.size(), start + num);
+        for (int i = start; i < end; i++) {
+            results.add(shardResults.data.get(i).getValue0());
+        }
+        return new SearchShardsResult(shardResults.count, results, shardResults.ids);
+    }
+
+    private String zsetCommon(Transaction trans, String method, int ttl, ZParams params, String... sets) {
+        String[] keys = new String[sets.length];
+        for (int i = 0; i < sets.length; i++) {
+            keys[i] = "idx:" + sets[i];
+        }
+
+        String id = UUID.randomUUID().toString();
+        try {
+            trans.getClass()
+                    .getDeclaredMethod(method, String.class, ZParams.class, String[].class)
+                    .invoke(trans, new Object[]{"idx:" + id, params, keys});
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        trans.expire("idx:" + id, ttl);
+        return id;
+    }
+
+    public String zintersect(Transaction trans, int ttl, ZParams params, String... sets) {
+        return zsetCommon(trans, "zinterstore", ttl, params, sets);
+    }
+
+    public String zunion(Transaction trans, int ttl, ZParams params, String... sets) {
+        return zsetCommon(trans, "zunionstore", ttl, params, sets);
+    }
+
+    @SuppressWarnings("unchecked")
+    public SearchResult searchAndZsort(Jedis conn, String queryStringString, boolean desc, Map<String, Integer> weights) {
+        int ttl = 300;
+        int start = 0;
+        int num = 20;
+
+        String id = parseAndSearch(conn, queryStringString, ttl);
+
+        int updateWeight = 1;
+        Integer uw = weights.get("update");
+        if (uw != null) updateWeight = uw.intValue();
+
+        int voteWeight = 0;
+        Integer vw = weights.get("vote");
+        if (vw != null) voteWeight = vw.intValue();
+
+        String[] keys = new String[]{id, "sort:update", "sort:votes"};
+        Transaction trans = conn.multi();
+        id = zintersect(trans, ttl, new ZParams().weights(0, updateWeight, voteWeight), keys);
+
+        trans.zcard("idx:" + id);
+        if (desc) {
+            trans.zrevrange("idx:" + id, start, start + num - 1);
+        } else {
+            trans.zrange("idx:" + id, start, start + num - 1);
+        }
+
+        List<Object> results = trans.exec();
+
+        return new SearchResult(
+                id,
+                ((Long) results.get(results.size() - 2)).longValue(),
+                new ArrayList<String>((Set<String>) results.get(results.size() - 1)));
+    }
+
+    public SearchResult searchAndZsort(Jedis conn, String queryStringString, String id, int ttl, int update, int vote, int start, int num, boolean desc) {
+        String baseId = (id != null) ? id : parseAndSearch(conn, queryStringString, ttl);
+        if (baseId == null) {
+            return new SearchResult(null, 0L, Collections.<String>emptyList());
+        }
+
+        conn.expire("idx:" + baseId, ttl);
+
+        String[] keys = new String[]{baseId, "sort:update", "sort:votes"};
+
+        Transaction trans = conn.multi();
+        String zsetId = zintersect(trans, ttl, new ZParams().weights(0, update, vote), keys);
+
+        trans.zcard("idx:" + zsetId);
+
+        if (desc) {
+            trans.zrevrange("idx:" + zsetId, start, start + num - 1);
+        } else {
+            trans.zrange("idx:" + zsetId, start, start + num - 1);
+        }
+
+        List<Object> res = trans.exec();
+        long count = ((Long) res.get(res.size() - 2)).longValue();
+
+        @SuppressWarnings("unchecked")
+        Set<String> docidSet = (Set<String>) res.get(res.size() - 1);
+
+        return new SearchResult(zsetId, count, new ArrayList<String>(docidSet));
+    }
+
+    public SearchZsetValuesResult searchGetZsetValues(Jedis conn, String query, String id, int ttl, int update, int vote, int start, int num, boolean desc) {
+        SearchResult sr = searchAndZsort(conn, query, id, ttl, update, vote, 0, 1, desc);
+
+        String zkey = "idx:" + sr.id;
+
+        Set<Tuple> data;
+        if (desc) {
+            data = conn.zrevrangeWithScores(zkey, 0, start + num - 1);
+        } else {
+            data = conn.zrangeWithScores(zkey, 0, start + num - 1);
+        }
+
+        return new SearchZsetValuesResult(sr.count, data, sr.id);
+    }
+
+    public SearchShardsZsetResult searchShardsZset(String component, int shards, String query, List<String> ids, int ttl, int update, int vote, int start, int num, boolean desc, int wait) {
+        long count = 0;
+        List<Tuple> data = new ArrayList<Tuple>();
+
+        if (ids == null) {
+            ids = new ArrayList<String>(shards);
+            for (int i = 0; i < shards; i++) ids.add(null);
+        }
+
+        for (int shard = 0; shard < shards; shard++) {
+            JedisPool pool = getRedisConnection(component + ":" + shard, wait);
+
+            Jedis conn = null;
+            boolean ok = true;
+            try {
+                conn = pool.getResource();
+                SearchZsetValuesResult r = searchGetZsetValues(conn, query, ids.get(shard), ttl, update, vote, start, num, desc);
+                count += r.count;
+                data.addAll(r.data);
+                ids.set(shard, r.id);
+            } catch (Exception e) {
+                ok = false;
+                if (conn != null) returnBrokenJedis(pool, conn);
+                throw new RuntimeException(e);
+            } finally {
+                if (ok && conn != null) returnJedis(pool, conn);
+            }
+        }
+
+        Collections.sort(data, new Comparator<Tuple>() {
+            public int compare(Tuple a, Tuple b) {
+                double diff = a.getScore() - b.getScore();
+                if (diff < 0) return -1;
+                if (diff > 0) return 1;
+                return 0;
+            }
+        });
+        if (desc) Collections.reverse(data);
+
+        List<String> results = new ArrayList<String>();
+        int end = Math.min(data.size(), start + num);
+        for (int i = start; i < end; i++) {
+            results.add(data.get(i).getElement());
+        }
+
+        return new SearchShardsZsetResult(count, results, ids);
+    }
+
+    private static final KeyShardedConnection shardedTimelines =
+            new KeyShardedConnection("timelines", SHARDED_TIMELINES_SHARDS, 1);
+
+    public boolean followUser(Jedis conn, long uid, long otherUid) {
+        String fkey1 = "following:" + uid;
+        String fkey2 = "followers:" + otherUid;
+
+        if (conn.zscore(fkey1, String.valueOf(otherUid)) != null) {
+            return false;
+        }
+
+        long now = System.currentTimeMillis() / 1000;
+
+        Transaction trans = conn.multi();
+        trans.zadd(fkey1, now, String.valueOf(otherUid));
+        trans.zadd(fkey2, now, String.valueOf(uid));
+        trans.zcard(fkey1);
+        trans.zcard(fkey2);
+
+        List<Object> response = trans.exec();
+        long following = ((Long) response.get(response.size() - 2)).longValue();
+        long followers = ((Long) response.get(response.size() - 1)).longValue(); // Java6: no getLast()
+
+        trans = conn.multi();
+        trans.hset("user:" + uid, "following", String.valueOf(following));
+        trans.hset("user:" + otherUid, "followers", String.valueOf(followers));
+        trans.exec();
+
+        String pkey = "profile:" + otherUid;
+        JedisPool profilePool = shardedTimelines.get(pkey);
+
+        Jedis pconn = null;
+        boolean ok = true;
+        Set<Tuple> statusAndScore;
+        try {
+            pconn = profilePool.getResource();
+            statusAndScore = pconn.zrevrangeWithScores(pkey, 0, HOME_TIMELINE_SIZE - 1);
+        } catch (Exception e) {
+            ok = false;
+            if (pconn != null) returnBrokenJedis(profilePool, pconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (ok && pconn != null) returnJedis(profilePool, pconn);
+        }
+
+        if (statusAndScore != null && !statusAndScore.isEmpty()) {
+            String hkey = "home:" + uid;
+            JedisPool homePool = shardedTimelines.get(hkey);
+
+            Jedis hconn = null;
+            boolean okh = true;
+            try {
+                hconn = homePool.getResource();
+                Transaction htrans = hconn.multi();
+                for (Tuple tuple : statusAndScore) {
+                    htrans.zadd(hkey, tuple.getScore(), tuple.getElement());
+                }
+                htrans.zremrangeByRank(hkey, 0, -HOME_TIMELINE_SIZE - 1);
+                htrans.exec();
+            } catch (Exception e) {
+                okh = false;
+                if (hconn != null) returnBrokenJedis(homePool, hconn);
+                throw new RuntimeException(e);
+            } finally {
+                if (okh && hconn != null) returnJedis(homePool, hconn);
+            }
+        }
+        return true;
+    }
+
+    private static final KeyDataShardedConnection shardedFollowers =
+            new KeyDataShardedConnection("followers", SHARDED_FOLLOWERS_SHARDS, 1);
+
+    public boolean followUser_2(Jedis conn, long uid, long otherUid) {
+        String fkey1 = "following:" + uid;
+        String fkey2 = "followers:" + otherUid;
+
+        JedisPool sp = shardedFollowers.get(uid, otherUid);
+        Jedis sconn = null;
+        boolean oks = true;
+
+        long followingAdded;
+        long followersAdded;
+
+        try {
+            sconn = sp.getResource();
+            if (sconn.zscore(fkey1, String.valueOf(otherUid)) != null) {
+                return false;
+            }
+            long now = System.currentTimeMillis() / 1000;
+
+            Transaction trans = sconn.multi();
+            trans.zadd(fkey1, now, String.valueOf(otherUid));
+            trans.zadd(fkey2, now, String.valueOf(uid));
+            List<Object> response = trans.exec();
+
+            followingAdded = ((Long) response.get(0)).longValue();
+            followersAdded = ((Long) response.get(1)).longValue();
+
+        } catch (Exception e) {
+            oks = false;
+            if (sconn != null) returnBrokenJedis(sp, sconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (oks && sconn != null) returnJedis(sp, sconn);
+        }
+
+        conn.hincrBy("user:" + uid, "following", followingAdded);
+        conn.hincrBy("user:" + otherUid, "followers", followersAdded);
+
+        String pkey = "profile:" + otherUid;
+
+        JedisPool ppool = shardedTimelines.get(pkey);
+        Jedis pconn = null;
+        boolean okp = true;
+        Set<Tuple> statusAndScore;
+
+        try {
+            pconn = ppool.getResource();
+            statusAndScore = pconn.zrevrangeWithScores(pkey, 0, HOME_TIMELINE_SIZE - 1);
+        } catch (Exception e) {
+            okp = false;
+            if (pconn != null) returnBrokenJedis(ppool, pconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (okp && pconn != null) returnJedis(ppool, pconn);
+        }
+
+        if (statusAndScore != null && !statusAndScore.isEmpty()) {
+            String hkey = "home:" + uid;
+            JedisPool hpool = shardedTimelines.get(hkey);
+
+            Jedis hconn = null;
+            boolean okh = true;
+            try {
+                hconn = hpool.getResource();
+                Transaction ht = hconn.multi();
+                for (Tuple tuple : statusAndScore) {
+                    ht.zadd(hkey, tuple.getScore(), tuple.getElement());
+                }
+                ht.zremrangeByRank(hkey, 0, -HOME_TIMELINE_SIZE - 1);
+                ht.exec();
+            } catch (Exception e) {
+                okh = false;
+                if (hconn != null) returnBrokenJedis(hpool, hconn);
+                throw new RuntimeException(e);
+            } finally {
+                if (okh && hconn != null) returnJedis(hpool, hconn);
+            }
+        }
+        return true;
+    }
+
+    public List<Tuple> shardedZrangeByScore(String component, int shards, String key, double min, String max, int num, int wait) {
+        List<Tuple> data = new ArrayList<Tuple>();
+
+        for (int shard = 0; shard < shards; shard++) {
+            JedisPool pool = getRedisConnection(component + ":" + shard, wait);
+            Jedis conn = null;
+            boolean ok = true;
+            try {
+                conn = pool.getResource();
+                Set<Tuple> part = conn.zrangeByScoreWithScores(key, String.valueOf(min), max, 0, num);
+                if (part != null) data.addAll(part);
+            } catch (Exception e) {
+                ok = false;
+                if (conn != null) returnBrokenJedis(pool, conn);
+                throw new RuntimeException(e);
+            } finally {
+                if (ok && conn != null) returnJedis(pool, conn);
+            }
+        }
+
+        Collections.sort(data, new Comparator<Tuple>() {
+            public int compare(Tuple o1, Tuple o2) {
+                double diff = o1.getScore() - o2.getScore();
+                if (diff < 0) return -1;
+                if (diff > 0) return 1;
+                return o1.getElement().compareTo(o2.getElement());
+            }
+        });
+
+        if (data.size() > num) {
+            return new ArrayList<Tuple>(data.subList(0, num));
+        }
+        return data;
+    }
+
+    public void syndicateStatus(long uid, Map<String, Double> post, double start, boolean onLists) {
+
+        String root = "followers";
+        String key = "followers:" + uid;
+        String base = "home:%s";
+
+        if (onLists) {
+            root = "list:out";
+            key = "list:out:" + uid;
+            base = "list:statuses:%s";
+        }
+
+        List<Tuple> followers = shardedZrangeByScore(
+                root,
+                SHARDED_FOLLOWERS_SHARDS,
+                key,
+                start,
+                "+inf",
+                POSTS_PER_PASS,
+                1
+        );
+
+        Map<String, List<String>> toSend = new HashMap<String, List<String>>();
+        double nextStart = start;
+
+        for (Tuple t : followers) {
+            String follower = t.getElement();
+            nextStart = t.getScore();
+
+            String timeline = String.format(base, follower);
+            String shard = shardKey("timelines", timeline, SHARDED_TIMELINES_SHARDS, 2);
+
+            List<String> timelines = toSend.get(shard);
+            if (timelines == null) {
+                timelines = new ArrayList<String>();
+                toSend.put(shard, timelines);
+            }
+            timelines.add(timeline);
+        }
+
+        for (List<String> timelines : toSend.values()) {
+            if (timelines == null || timelines.isEmpty()) continue;
+
+            JedisPool pool = shardedTimelines.get(timelines.get(0));
+            Jedis j = null;
+            boolean ok = true;
+            try {
+                j = pool.getResource();
+                Pipeline pipe = j.pipelined();
+
+                for (String timeline : timelines) {
+                    for (Map.Entry<String, Double> e : post.entrySet()) {
+                        pipe.zadd(timeline, e.getValue().doubleValue(), e.getKey());
+                    }
+                    pipe.zremrangeByRank(timeline, 0, -HOME_TIMELINE_SIZE - 1);
+                }
+                pipe.sync();
+            } catch (Exception e) {
+                ok = false;
+                if (j != null) returnBrokenJedis(pool, j);
+                throw new RuntimeException(e);
+            } finally {
+                if (ok && j != null) returnJedis(pool, j);
+            }
+        }
+
+        JedisPool dpool = getRedisConnection("default", 1);
+        Jedis defaultConn = null;
+        boolean okd = true;
+        try {
+            defaultConn = dpool.getResource();
+
+            Gson gson = new Gson();
+            List<String> args = new ArrayList<String>(4);
+            args.add(String.valueOf(uid));
+            args.add(gson.toJson(post));
+            args.add(String.valueOf(nextStart));
+            args.add(String.valueOf(onLists));
+
+            if (followers.size() >= POSTS_PER_PASS) {
+                executeLater(defaultConn, "default", "syndicate_status", args, 0);
+            } else if (!onLists) {
+                args.set(2, "0");
+                args.set(3, "true");
+                executeLater(defaultConn, "default", "syndicate_status", args, 0);
+            }
+        } catch (Exception e) {
+            okd = false;
+            if (defaultConn != null) returnBrokenJedis(dpool, defaultConn);
+            throw new RuntimeException(e);
+        } finally {
+            if (okd && defaultConn != null) returnJedis(dpool, defaultConn);
+        }
+    }
+
+    private static JedisPool createJedisPoolFromConfig(Map<String, Object> config) {
+        String host = asString(config.get("host"), "127.0.0.1");
+        int port = asInt(config.get("port"), 6379);
+        int db = asInt(config.get("db"), 0);
+        String password = asString(config.get("password"), null);
+        int timeoutMillis = asInt(config.get("timeoutMillis"), 2000);
+
+        JedisPoolConfig poolConfig = new JedisPoolConfig();
+        if (password != null && password.trim().length() > 0) {
+            return new JedisPool(poolConfig, host, port, timeoutMillis, password, db);
+        }
+        return new JedisPool(poolConfig, host, port, timeoutMillis, null, db);
+    }
+
+    private static String asString(Object value, String def) {
+        if (value == null) return def;
+        return String.valueOf(value);
+    }
+
+    private static int asInt(Object value, int def) {
+        if (value == null) return def;
+        if (value instanceof Integer) return ((Integer) value).intValue();
+        if (value instanceof Long) return ((Long) value).intValue();
+        if (value instanceof Double) return ((Double) value).intValue();
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (Exception e) {
+            return def;
+        }
+    }
+
+    public String executeLater(Jedis conn, String queue, String name, List<String> args, long delay) {
+        Gson gson = new Gson();
+        String identifier = UUID.randomUUID().toString();
+        String itemArgs = gson.toJson(args);
+        String item = gson.toJson(new String[]{identifier, queue, name, itemArgs});
+        if (delay > 0) {
+            conn.zadd("delayed:", System.currentTimeMillis() + delay, item);
+        } else {
+            conn.rpush("queue:" + queue, item);
+        }
+        return identifier;
+    }
+
+    public String acquireLock(Jedis conn, String lockName) {
+        return acquireLock(conn, lockName, 10000);
+    }
+
+    public String acquireLock(Jedis conn, String lockName, long acquireTimeout) {
+        String identifier = UUID.randomUUID().toString();
+
+        long end = System.currentTimeMillis() + acquireTimeout;
+        while (System.currentTimeMillis() < end) {
+            if (conn.setnx("lock:" + lockName, identifier) == 1) {
+                return identifier;
+            }
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return null;
+    }
+
+    public boolean releaseLock(Jedis conn, String lockName, String identifier) {
+        String lockKey = "lock:" + lockName;
+
+        while (true) {
+            conn.watch(lockKey);
+            if (identifier.equals(conn.get(lockKey))) {
+                Transaction trans = conn.multi();
+                trans.del(lockKey);
+                List<Object> results = trans.exec();
+                if (results == null) {
+                    continue;
+                }
+                return true;
+            }
+            conn.unwatch();
+            break;
+        }
+        return false;
+    }
+
+    public static final class KeyShardedConnection {
+        private final String component;
+        private final int shards;
+        private final int wait;
+
+        public KeyShardedConnection(String component, int shards) {
+            this(component, shards, 1);
+        }
+
+        public KeyShardedConnection(String component, int shards, int wait) {
+            this.component = component;
+            this.shards = shards;
+            this.wait = wait;
+        }
+
+        public JedisPool get(String key) {
+            return getShardedConnection(component, key, shards, wait);
+        }
+    }
+
+    public static final class KeyDataShardedConnection {
+        private final String component;
+        private final int shards;
+        private final int wait;
+
+        public KeyDataShardedConnection(String component, int shards) {
+            this(component, shards, 1);
+        }
+
+        public KeyDataShardedConnection(String component, int shards, int wait) {
+            this.component = component;
+            this.shards = shards;
+            this.wait = wait;
+        }
+
+        public JedisPool get(long id1, long id2) {
+            if (id2 < id1) {
+                long tmp = id1;
+                id1 = id2;
+                id2 = tmp;
+            }
+            String key = id1 + ":" + id2;
+            return getShardedConnection(component, key, shards, wait);
+        }
+    }
+
+    public class PollQueueThread extends Thread {
+        private Jedis conn;
+        private boolean quit;
+        private Gson gson = new Gson();
+
+        public PollQueueThread() {
+            this.conn = new Jedis("localhost");
+            this.conn.select(15);
+        }
+
+        public void quitThread() {
+            quit = true;
+        }
+
+        public void run() {
+            while (!quit) {
+                Set<Tuple> items = conn.zrangeWithScores("delayed:", 0, 0);
+                Tuple item = (items != null && items.size() > 0) ? items.iterator().next() : null;
+
+                if (item == null || item.getScore() > System.currentTimeMillis()) {
+                    try {
+                        sleep(10);
+                    } catch (InterruptedException ie) {
+                        Thread.interrupted();
+                    }
+                    continue;
+                }
+
+                String json = item.getElement();
+                String[] values = (String[]) gson.fromJson(json, String[].class);
+                String identifier = values[0];
+                String queue = values[1];
+
+                String locked = acquireLock(conn, identifier);
+                if (locked == null) {
+                    continue;
+                }
+
+                if (conn.zrem("delayed:", json) == 1) {
+                    conn.rpush("queue:" + queue, json);
+                }
+
+                releaseLock(conn, identifier, locked);
+            }
+        }
+    }
+
+    public static final class SearchResult {
+        public final String id;
+        public final long count;
+        public final List<String> docids;
+
+        public SearchResult(String id, long count, List<String> docids) {
+            this.id = id;
+            this.count = count;
+            this.docids = docids;
+        }
+    }
+
+    public static final class SearchGetValuesResult {
+        public final long count;
+        public final List<Pair<String, String>> dataPairs;
+        public final String id;
+
+        public SearchGetValuesResult(long count, List<Pair<String, String>> dataPairs, String id) {
+            this.count = count;
+            this.dataPairs = dataPairs;
+            this.id = id;
+        }
+    }
+
+    public static final class ShardResults {
+        public final long count;
+        public final List<Pair<String, String>> data;
+        public final List<String> ids;
+
+        public ShardResults(long count, List<Pair<String, String>> data, List<String> ids) {
+            this.count = count;
+            this.data = data;
+            this.ids = ids;
+        }
+    }
+
+    public static final class SearchShardsResult {
+        public final long count;
+        public final List<String> results;
+        public final List<String> ids;
+
+        public SearchShardsResult(long count, List<String> results, List<String> ids) {
+            this.count = count;
+            this.results = results;
+            this.ids = ids;
+        }
+    }
+
+    public static final class SearchZsetValuesResult {
+        public final long count;
+        public final Set<Tuple> data;
+        public final String id;
+
+        public SearchZsetValuesResult(long count, Set<Tuple> data, String id) {
+            this.count = count;
+            this.data = data;
+            this.id = id;
+        }
+    }
+
+    public static final class SearchShardsZsetResult {
+        public final long count;
+        public final List<String> results;
+        public final List<String> ids;
+
+        public SearchShardsZsetResult(long count, List<String> results, List<String> ids) {
+            this.count = count;
+            this.results = results;
+            this.ids = ids;
+        }
+    }
+}

--- a/java/src/main/java/Chapter10.java
+++ b/java/src/main/java/Chapter10.java
@@ -68,6 +68,7 @@ public class Chapter10 {
         new Chapter10().run();
     }
 
+    // Run all tests and seed configuration data.
     public void run() throws Exception {
         for (int db : new int[]{11, 12, 13, 14, 15}) {
             Jedis j = new Jedis("localhost");
@@ -94,6 +95,7 @@ public class Chapter10 {
         System.out.println("\nALL TESTS DONE.");
     }
 
+    // Seed Redis with configuration keys for different shards.
     private void seedRedisConfigs(Jedis conn) {
         System.out.println("\n----- seedRedisConfigs -----");
 
@@ -132,6 +134,7 @@ public class Chapter10 {
         System.out.println("seed done.");
     }
 
+    // Test countVisit by incrementing unique visitor count.
     public void testCountVisit(Jedis conn) {
         System.out.println("\n----- testCountVisit -----");
 
@@ -149,6 +152,7 @@ public class Chapter10 {
         assert v != null && Long.parseLong(v) >= 1L;
     }
 
+    // Test searchAndSort with different sort fields.
     public void testSearchAndSort(Jedis conn, Chapter10 ch10) {
         System.out.println("\n----- testSearchAndSort -----");
 
@@ -188,6 +192,7 @@ public class Chapter10 {
         assert "1".equals(r3.docids.get(2));
     }
 
+    // Test followUser by following a user and verifying home timeline.
     public void testFollowUser(Jedis conn, Chapter10 ch10) {
         System.out.println("\n----- testFollowUser -----");
 
@@ -269,6 +274,7 @@ public class Chapter10 {
         }
     }
 
+    // Test delayed task execution via executeLater and PollQueueThread.
     public void testDelayedTasks(Jedis conn, Chapter10 ch10) throws Exception {
         System.out.println("\n----- testDelayedTasks -----");
 
@@ -293,6 +299,7 @@ public class Chapter10 {
         t.join(1000);
     }
 
+    // Helper: convert tuple set to list of element strings.
     private List<String> tuplesToElements(Set<Tuple> tuples) {
         List<String> out = new ArrayList<String>();
         if (tuples == null) return out;
@@ -302,32 +309,37 @@ public class Chapter10 {
         return out;
     }
 
-
+    // Return a Jedis instance to the pool.
     private static void returnJedis(JedisPool pool, Jedis jedis) {
         if (pool != null && jedis != null) {
             pool.returnResource(jedis);
         }
     }
 
+    // Return a broken Jedis instance to the pool.
     private static void returnBrokenJedis(JedisPool pool, Jedis jedis) {
         if (pool != null && jedis != null) {
             pool.returnBrokenResource(jedis);
         }
     }
 
+    // Check object equality with null safety.
     private static boolean eq(Object a, Object b) {
         return a == b || (a != null && a.equals(b));
     }
 
+    // Get long from map with default.
     private static long getOrDefaultLong(Map<String, Long> map, String key, long def) {
         Long v = map.get(key);
         return v != null ? v.longValue() : def;
     }
 
+    // Set the global configuration connection pool.
     public static void setConfigConnection(JedisPool configConn) {
         configConnection = configConn;
     }
 
+    // Fetch configuration for a component, refreshing if older than wait seconds.
     public static Map<String, Object> getConfig(JedisPool conn, String type, String component, int wait) {
         String key = "config:" + type + ":" + component;
         long now = System.currentTimeMillis();
@@ -364,11 +376,13 @@ public class Chapter10 {
         return CONFIGS.get(key);
     }
 
+    // Parse JSON string into a Map.
     private static Map<String, Object> parseJsonToMap(String json) {
         Map<String, Object> map = (Map<String, Object>) GSON.fromJson(json, MAP_TYPE);
         return (map == null) ? Collections.<String, Object>emptyMap() : map;
     }
 
+    // Compute shard key for a given base and member.
     public static String shardKey(String base, String key, long totalElements, int shardSize) {
         long shardId;
         if (isDigit(key)) {
@@ -382,6 +396,7 @@ public class Chapter10 {
         return base + ":" + shardId;
     }
 
+    // Check if string contains only digits.
     public static boolean isDigit(String str) {
         if (str == null || str.length() == 0) return false;
         for (int i = 0; i < str.length(); i++) {
@@ -390,6 +405,7 @@ public class Chapter10 {
         return true;
     }
 
+    // Get Redis connection pool for a component.
     public static JedisPool getRedisConnection(String component, int wait) {
         String key = "config:redis:" + component;
         Map<String, Object> oldConfig = CONFIGS.get(key);
@@ -404,19 +420,23 @@ public class Chapter10 {
         return REDIS_CONNECTIONS.get(key);
     }
 
+    // Get sharded Redis connection for a component based on key.
     public static JedisPool getShardedConnection(String component, String key, long shardCount, int wait) {
         String shard = shardKey(component, "x" + String.valueOf(key), shardCount, 2);
         return getRedisConnection(shard, wait);
     }
 
+    // Functional interface for sharded operations.
     public interface ShardedFunction<T> {
         T call(JedisPool conn, String key, Object... args);
     }
 
+    // Interface for callers that need sharding.
     public interface ShardedCaller<T> {
         T call(String key, Object... args);
     }
 
+    // Create a sharded caller that resolves connection per key.
     public static <T> ShardedCaller<T> shardedConnection(
             final String component,
             final long shardCount,
@@ -431,6 +451,7 @@ public class Chapter10 {
         };
     }
 
+    // Get expected cardinality for unique set.
     public static long getExpected(Jedis conn, String key, Calendar today) {
         if (!EXPECTED.containsKey(key)) {
             String exkey = key + ":expected";
@@ -458,6 +479,7 @@ public class Chapter10 {
         return v != null ? v.longValue() : 0L;
     }
 
+    // Get expected value along with the connection pool.
     public static Pair<JedisPool, Long> getExpected(String key, Calendar today) {
         JedisPool pool = getRedisConnection("unique", 1);
         Jedis jedis = null;
@@ -475,6 +497,7 @@ public class Chapter10 {
         }
     }
 
+    // Sharded caller for counting unique visits.
     public static final ShardedCaller<Void> COUNT_VISIT =
             shardedConnection("unique", 16, 1, new ShardedFunction<Void>() {
                 public Void call(JedisPool pool, String sessionId, Object... args) {
@@ -519,20 +542,24 @@ public class Chapter10 {
                 }
             });
 
+    // Record a unique visit.
     public static void countVisit(String sessionId) {
         COUNT_VISIT.call(sessionId, new Object[0]);
     }
 
+    // Add member to a sharded set.
     public static Long shardSadd(Jedis conn, String base, long member, long totalElements, int shardSize) {
         String shard = shardKey(base, "x" + String.valueOf(member), totalElements, shardSize);
         return conn.sadd(shard, String.valueOf(member));
     }
 
+    // Query parsing result holder.
     public static final class Query {
         public final List<List<String>> all = new ArrayList<List<String>>();
         public final Set<String> unwanted = new HashSet<String>();
     }
 
+    // Helper for set operations with TTL.
     private String setCommon(Transaction trans, String method, int ttl, String... items) {
         String[] keys = new String[items.length];
         for (int i = 0; i < items.length; i++) {
@@ -551,18 +578,22 @@ public class Chapter10 {
         return id;
     }
 
+    // Perform set intersection and store with TTL.
     public String intersect(Transaction trans, int ttl, String... items) {
         return setCommon(trans, "sinterstore", ttl, items);
     }
 
+    // Perform set union and store with TTL.
     public String union(Transaction trans, int ttl, String... items) {
         return setCommon(trans, "sunionstore", ttl, items);
     }
 
+    // Perform set difference and store with TTL.
     public String difference(Transaction trans, int ttl, String... items) {
         return setCommon(trans, "sdiffstore", ttl, items);
     }
 
+    // Parse search query into required and unwanted words.
     public Query parse(String queryStringString) {
         Query queryString = new Query();
         Set<String> current = new HashSet<String>();
@@ -598,6 +629,7 @@ public class Chapter10 {
         return queryString;
     }
 
+    // Parse query and store result set with TTL.
     public String parseAndSearch(Jedis conn, String queryStringString, int ttl) {
         Query queryString = parse(queryStringString);
         if (queryString.all.isEmpty()) return null;
@@ -633,10 +665,12 @@ public class Chapter10 {
         return intersectResult;
     }
 
+    // Search and sort with default parameters.
     public SearchResult searchAndSort(Jedis conn, String queryStringString, String sort) {
         return searchAndSort(conn, queryStringString, null, 300, sort, 0, 20);
     }
 
+    // Search and sort with full parameters.
     public SearchResult searchAndSort(Jedis conn, String queryStringString, String id, int ttl, String sort, int start, int num) {
         boolean desc = sort.startsWith("-");
         if (desc) sort = sort.substring(1);
@@ -671,6 +705,7 @@ public class Chapter10 {
         return new SearchResult(rid, count, docids);
     }
 
+    // Search, sort, and fetch additional field values.
     public SearchGetValuesResult searchGetValues(Jedis conn, String queryString, String id, int ttl, String sort, int start, int num) {
         SearchResult searchResult = searchAndSort(conn, queryString, id, ttl, sort, 0, start + num);
         String keyPattern = "kb:doc:%s";
@@ -694,6 +729,7 @@ public class Chapter10 {
         return new SearchGetValuesResult(searchResult.count, dataPairs, searchResult.id);
     }
 
+    // Fetch search results from all shards.
     public ShardResults getShardResults(String component, int shards, String queryString, List<String> ids, int ttl, String sort, int start, int num, int wait) {
         long count = 0;
         List<Pair<String, String>> data = new ArrayList<Pair<String, String>>();
@@ -724,6 +760,7 @@ public class Chapter10 {
         return new ShardResults(count, data, ids);
     }
 
+    // Convert pair to numeric key for sorting.
     private static BigDecimal toNumericKey(Pair<String, String> data) {
         try {
             String s = data.getValue1();
@@ -734,11 +771,13 @@ public class Chapter10 {
         }
     }
 
+    // Convert pair to string key for sorting.
     private static String toStringKey(Pair<String, String> data) {
         String s = data.getValue1();
         return (s == null) ? "" : s;
     }
 
+    // Merge sorted shard results into a single sorted list.
     public SearchShardsResult searchShards(String component, int shards, String queryString, List<String> ids, int ttl, String sort, int start, int num, int wait) {
         ShardResults shardResults = getShardResults(component, shards, queryString, ids, ttl, sort, start, num, wait);
 
@@ -774,6 +813,7 @@ public class Chapter10 {
         return new SearchShardsResult(shardResults.count, results, shardResults.ids);
     }
 
+    // Helper for ZSET store operations.
     private String zsetCommon(Transaction trans, String method, int ttl, ZParams params, String... sets) {
         String[] keys = new String[sets.length];
         for (int i = 0; i < sets.length; i++) {
@@ -792,14 +832,17 @@ public class Chapter10 {
         return id;
     }
 
+    // ZINTERSTORE with TTL.
     public String zintersect(Transaction trans, int ttl, ZParams params, String... sets) {
         return zsetCommon(trans, "zinterstore", ttl, params, sets);
     }
 
+    // ZUNIONSTORE with TTL.
     public String zunion(Transaction trans, int ttl, ZParams params, String... sets) {
         return zsetCommon(trans, "zunionstore", ttl, params, sets);
     }
 
+    // Search and ZSET sort with weights.
     @SuppressWarnings("unchecked")
     public SearchResult searchAndZsort(Jedis conn, String queryStringString, boolean desc, Map<String, Integer> weights) {
         int ttl = 300;
@@ -835,6 +878,7 @@ public class Chapter10 {
                 new ArrayList<String>((Set<String>) results.get(results.size() - 1)));
     }
 
+    // Search and ZSET sort with explicit parameters.
     public SearchResult searchAndZsort(Jedis conn, String queryStringString, String id, int ttl, int update, int vote, int start, int num, boolean desc) {
         String baseId = (id != null) ? id : parseAndSearch(conn, queryStringString, ttl);
         if (baseId == null) {
@@ -865,6 +909,7 @@ public class Chapter10 {
         return new SearchResult(zsetId, count, new ArrayList<String>(docidSet));
     }
 
+    // Search and retrieve values with scores.
     public SearchZsetValuesResult searchGetZsetValues(Jedis conn, String query, String id, int ttl, int update, int vote, int start, int num, boolean desc) {
         SearchResult sr = searchAndZsort(conn, query, id, ttl, update, vote, 0, 1, desc);
 
@@ -880,6 +925,7 @@ public class Chapter10 {
         return new SearchZsetValuesResult(sr.count, data, sr.id);
     }
 
+    // Search across shards using ZSETs.
     public SearchShardsZsetResult searchShardsZset(String component, int shards, String query, List<String> ids, int ttl, int update, int vote, int start, int num, boolean desc, int wait) {
         long count = 0;
         List<Tuple> data = new ArrayList<Tuple>();
@@ -928,9 +974,11 @@ public class Chapter10 {
         return new SearchShardsZsetResult(count, results, ids);
     }
 
+    // Sharded connection for timelines.
     private static final KeyShardedConnection shardedTimelines =
             new KeyShardedConnection("timelines", SHARDED_TIMELINES_SHARDS, 1);
 
+    // Follow a user and update home timeline with profile posts.
     public boolean followUser(Jedis conn, long uid, long otherUid) {
         String fkey1 = "following:" + uid;
         String fkey2 = "followers:" + otherUid;
@@ -998,9 +1046,11 @@ public class Chapter10 {
         return true;
     }
 
+    // Alternative sharded follower implementation.
     private static final KeyDataShardedConnection shardedFollowers =
             new KeyDataShardedConnection("followers", SHARDED_FOLLOWERS_SHARDS, 1);
 
+    // Follow user using sharded connections for followers/following.
     public boolean followUser_2(Jedis conn, long uid, long otherUid) {
         String fkey1 = "following:" + uid;
         String fkey2 = "followers:" + otherUid;
@@ -1081,6 +1131,7 @@ public class Chapter10 {
         return true;
     }
 
+    // Retrieve elements from sharded ZSETs by score range.
     public List<Tuple> shardedZrangeByScore(String component, int shards, String key, double min, String max, int num, int wait) {
         List<Tuple> data = new ArrayList<Tuple>();
 
@@ -1116,6 +1167,7 @@ public class Chapter10 {
         return data;
     }
 
+    // Syndicate a status to followers' home timelines.
     public void syndicateStatus(long uid, Map<String, Double> post, double start, boolean onLists) {
 
         String root = "followers";
@@ -1211,6 +1263,7 @@ public class Chapter10 {
         }
     }
 
+    // Create JedisPool from configuration map.
     private static JedisPool createJedisPoolFromConfig(Map<String, Object> config) {
         String host = asString(config.get("host"), "127.0.0.1");
         int port = asInt(config.get("port"), 6379);
@@ -1225,11 +1278,13 @@ public class Chapter10 {
         return new JedisPool(poolConfig, host, port, timeoutMillis, null, db);
     }
 
+    // Convert object to string with default.
     private static String asString(Object value, String def) {
         if (value == null) return def;
         return String.valueOf(value);
     }
 
+    // Convert object to int with default.
     private static int asInt(Object value, int def) {
         if (value == null) return def;
         if (value instanceof Integer) return ((Integer) value).intValue();
@@ -1242,6 +1297,7 @@ public class Chapter10 {
         }
     }
 
+    // Schedule a task to run later or immediately.
     public String executeLater(Jedis conn, String queue, String name, List<String> args, long delay) {
         Gson gson = new Gson();
         String identifier = UUID.randomUUID().toString();
@@ -1255,10 +1311,12 @@ public class Chapter10 {
         return identifier;
     }
 
+    // Acquire a lock with default timeout.
     public String acquireLock(Jedis conn, String lockName) {
         return acquireLock(conn, lockName, 10000);
     }
 
+    // Acquire a lock with specified timeout.
     public String acquireLock(Jedis conn, String lockName, long acquireTimeout) {
         String identifier = UUID.randomUUID().toString();
 
@@ -1276,6 +1334,7 @@ public class Chapter10 {
         return null;
     }
 
+    // Release a previously acquired lock.
     public boolean releaseLock(Jedis conn, String lockName, String identifier) {
         String lockKey = "lock:" + lockName;
 
@@ -1296,6 +1355,7 @@ public class Chapter10 {
         return false;
     }
 
+    // Helper class for sharded connections keyed by a single key.
     public static final class KeyShardedConnection {
         private final String component;
         private final int shards;
@@ -1311,11 +1371,13 @@ public class Chapter10 {
             this.wait = wait;
         }
 
+        // Get connection pool for a given key.
         public JedisPool get(String key) {
             return getShardedConnection(component, key, shards, wait);
         }
     }
 
+    // Helper class for sharded connections keyed by a pair of IDs.
     public static final class KeyDataShardedConnection {
         private final String component;
         private final int shards;
@@ -1331,6 +1393,7 @@ public class Chapter10 {
             this.wait = wait;
         }
 
+        // Get connection pool for a pair of IDs, ordering them.
         public JedisPool get(long id1, long id2) {
             if (id2 < id1) {
                 long tmp = id1;
@@ -1342,6 +1405,7 @@ public class Chapter10 {
         }
     }
 
+    // Thread that polls delayed tasks and moves them to queues.
     public class PollQueueThread extends Thread {
         private Jedis conn;
         private boolean quit;
@@ -1389,6 +1453,7 @@ public class Chapter10 {
         }
     }
 
+    // Result holder for search operations.
     public static final class SearchResult {
         public final String id;
         public final long count;
@@ -1401,6 +1466,7 @@ public class Chapter10 {
         }
     }
 
+    // Result holder for search with additional field values.
     public static final class SearchGetValuesResult {
         public final long count;
         public final List<Pair<String, String>> dataPairs;
@@ -1413,6 +1479,7 @@ public class Chapter10 {
         }
     }
 
+    // Intermediate result for shard queries.
     public static final class ShardResults {
         public final long count;
         public final List<Pair<String, String>> data;
@@ -1425,6 +1492,7 @@ public class Chapter10 {
         }
     }
 
+    // Final result for sharded search with sorting.
     public static final class SearchShardsResult {
         public final long count;
         public final List<String> results;
@@ -1437,6 +1505,7 @@ public class Chapter10 {
         }
     }
 
+    // Result holder for ZSET search with values.
     public static final class SearchZsetValuesResult {
         public final long count;
         public final Set<Tuple> data;
@@ -1449,6 +1518,7 @@ public class Chapter10 {
         }
     }
 
+    // Final result for sharded ZSET search.
     public static final class SearchShardsZsetResult {
         public final long count;
         public final List<String> results;

--- a/java/src/main/java/Chapter10.java
+++ b/java/src/main/java/Chapter10.java
@@ -69,10 +69,15 @@ public class Chapter10 {
     }
 
     public void run() throws Exception {
+        for (int db : new int[]{11, 12, 13, 14, 15}) {
+            Jedis j = new Jedis("localhost");
+            j.select(db);
+            j.flushDB();
+            j.disconnect();
+        }
+
         Jedis conn = new Jedis("localhost");
         conn.select(15);
-
-        conn.flushDB();
 
         seedRedisConfigs(conn);
 
@@ -92,24 +97,35 @@ public class Chapter10 {
     private void seedRedisConfigs(Jedis conn) {
         System.out.println("\n----- seedRedisConfigs -----");
 
-        String json = "{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":15,\"timeoutMillis\":2000}";
+        String defaultJson = "{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":15,\"timeoutMillis\":2000}";
+        conn.set("config:redis:default", defaultJson);
+        conn.set("config:redis:unique", defaultJson);
 
-        conn.set("config:redis:default", json);
-        conn.set("config:redis:unique", json);
-
+        int[] uniqueDbs = {13, 14};
         for (int i = 0; i < 16; i++) {
+            int db = uniqueDbs[i % uniqueDbs.length];
+            String json = String.format("{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":%d,\"timeoutMillis\":2000}", db);
             conn.set("config:redis:unique:" + i, json);
         }
 
+        int[] timelineDbs = {11, 12, 13, 14};
         for (int i = 0; i < 8; i++) {
+            int db = timelineDbs[i % timelineDbs.length];
+            String json = String.format("{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":%d,\"timeoutMillis\":2000}", db);
             conn.set("config:redis:timelines:" + i, json);
         }
 
+        int[] followerDbs = {11, 12, 13, 14};
         for (int i = 0; i < 16; i++) {
+            int db = followerDbs[i % followerDbs.length];
+            String json = String.format("{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":%d,\"timeoutMillis\":2000}", db);
             conn.set("config:redis:followers:" + i, json);
         }
 
+        int[] listOutDbs = {11, 12, 13, 14};
         for (int i = 0; i < 16; i++) {
+            int db = listOutDbs[i % listOutDbs.length];
+            String json = String.format("{\"host\":\"127.0.0.1\",\"port\":6379,\"db\":%d,\"timeoutMillis\":2000}", db);
             conn.set("config:redis:list:out:" + i, json);
         }
 
@@ -185,24 +201,72 @@ public class Chapter10 {
 
         String pkey = "profile:" + otherUid;
         String hkey = "home:" + uid;
-        conn.del(pkey);
-        conn.del(hkey);
+
+        JedisPool profilePool = shardedTimelines.get(pkey);
+        JedisPool homePool = shardedTimelines.get(hkey);
+
+        Jedis pconn = null;
+        boolean okp = true;
+        try {
+            pconn = profilePool.getResource();
+            pconn.del(pkey);
+        } catch (Exception e) {
+            okp = false;
+            if (pconn != null) returnBrokenJedis(profilePool, pconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (okp && pconn != null) returnJedis(profilePool, pconn);
+        }
+
+        Jedis hconn = null;
+        boolean okh = true;
+        try {
+            hconn = homePool.getResource();
+            hconn.del(hkey);
+        } catch (Exception e) {
+            okh = false;
+            if (hconn != null) returnBrokenJedis(homePool, hconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (okh && hconn != null) returnJedis(homePool, hconn);
+        }
 
         double now = System.currentTimeMillis() / 1000.0;
-        conn.zadd(pkey, now - 10, "status:1");
-        conn.zadd(pkey, now - 5, "status:2");
+        pconn = null;
+        okp = true;
+        try {
+            pconn = profilePool.getResource();
+            pconn.zadd(pkey, now - 10, "status:1");
+            pconn.zadd(pkey, now - 5, "status:2");
+        } catch (Exception e) {
+            okp = false;
+            if (pconn != null) returnBrokenJedis(profilePool, pconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (okp && pconn != null) returnJedis(profilePool, pconn);
+        }
 
         boolean ok = ch10.followUser(conn, uid, otherUid);
         System.out.println("followUser => " + ok);
         assert ok;
 
-        Set<Tuple> home = conn.zrevrangeWithScores(hkey, 0, -1);
-        System.out.println("home timeline => " + tuplesToElements(home));
-        assert home != null && home.size() >= 2;
-
-        List<String> elems = tuplesToElements(home);
-        assert elems.contains("status:1");
-        assert elems.contains("status:2");
+        hconn = null;
+        okh = true;
+        try {
+            hconn = homePool.getResource();
+            Set<Tuple> home = hconn.zrevrangeWithScores(hkey, 0, -1);
+            System.out.println("home timeline => " + tuplesToElements(home));
+            assert home != null && home.size() >= 2;
+            List<String> elems = tuplesToElements(home);
+            assert elems.contains("status:1");
+            assert elems.contains("status:2");
+        } catch (Exception e) {
+            okh = false;
+            if (hconn != null) returnBrokenJedis(homePool, hconn);
+            throw new RuntimeException(e);
+        } finally {
+            if (okh && hconn != null) returnJedis(homePool, hconn);
+        }
     }
 
     public void testDelayedTasks(Jedis conn, Chapter10 ch10) throws Exception {

--- a/java/src/main/java/Chapter11.java
+++ b/java/src/main/java/Chapter11.java
@@ -1,0 +1,785 @@
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Chapter11 {
+    private static final String VALID_CHARACTERS = "`abcdefghijklmnopqrstuvwxyz{";
+    private static final int PUSH_CHUNK_SIZE = 64;
+    private static final String DUMMY = UUID.randomUUID().toString();
+
+    public static void main(String[] args) throws Exception {
+        new Chapter11().run();
+    }
+
+    public void run() throws Exception {
+        Jedis conn = new Jedis("localhost");
+        conn.select(15);
+
+        System.out.println("Using Redis DB 15. Flushing DB 15...");
+        conn.flushDB();
+
+        testScriptLoad(conn);
+        testCreateStatus(conn);
+        testDistributedLockingLua(conn);
+        testCountingSemaphoreLua(conn);
+        testAutocompleteLua(conn);
+        testPurchaseItemLua(conn);
+        testShardedListPushPop(conn);
+        testShardedBlockingPop(conn);
+
+        System.out.println("\nALL Chapter 11 tests passed.");
+    }
+
+    public void testScriptLoad(Jedis conn) {
+        System.out.println("\n----- testScriptLoad -----");
+        Chapter11.ScriptFn fn = Chapter11.scriptLoad("return 1");
+
+        Object r1 = fn.call(conn);
+        System.out.println("First call result: " + r1);
+        assert "1".equals(String.valueOf(r1));
+
+        conn.scriptFlush();
+        Object r2 = fn.call(conn);
+        System.out.println("After SCRIPT FLUSH, call result: " + r2);
+        assert "1".equals(String.valueOf(r2));
+
+        Object r3 = fn.call(conn, Collections.<String>emptyList(), Collections.<String>emptyList(), true);
+        System.out.println("force_eval call result: " + r3);
+        assert "1".equals(String.valueOf(r3));
+
+        System.out.println("scriptLoad() OK.");
+    }
+
+    public void testCreateStatus(Jedis conn) {
+        System.out.println("\n----- testCreateStatus -----");
+
+        conn.del("user:100", "status:id:");
+        Long noUser = Chapter11.createStatus(conn, "100", "hello");
+        System.out.println("createStatus without user login => " + noUser);
+        assert noUser == null;
+
+        conn.hset("user:100", "login", "tom");
+        conn.hset("user:100", "posts", "0");
+
+        Map<String, String> extra = new HashMap<String, String>();
+        extra.put("extra_field", "extra_value");
+
+        Long sid = Chapter11.createStatus(conn, "100", "hello redis lua", extra);
+        System.out.println("created status id => " + sid);
+        assert sid != null && sid > 0;
+
+        String skey = "status:" + sid;
+        Map<String, String> status = conn.hgetAll(skey);
+        System.out.println("status hash => " + status);
+
+        assert "tom".equals(status.get("login"));
+        assert String.valueOf(sid).equals(status.get("id"));
+        assert "hello redis lua".equals(status.get("message"));
+        assert "100".equals(status.get("uid"));
+        assert status.get("posted") != null;
+        assert "extra_value".equals(status.get("extra_field"));
+
+        String posts = conn.hget("user:100", "posts");
+        System.out.println("user posts => " + posts);
+        assert "1".equals(posts);
+
+        conn.del("user:100", "status:id:", skey);
+        System.out.println("createStatus() OK.");
+    }
+
+    public void testDistributedLockingLua(Jedis conn) throws InterruptedException {
+        System.out.println("\n----- testDistributedLockingLua -----");
+
+        conn.del("lock:testlock");
+
+        System.out.println("Acquiring lock first time...");
+        String id1 = Chapter11.acquireLockWithTimeout(conn, "testlock", 2, 2);
+        assert id1 != null;
+        System.out.println("Got lock id: " + id1);
+
+        System.out.println("Trying to acquire again without releasing (should fail quickly)...");
+        String id2 = Chapter11.acquireLockWithTimeout(conn, "testlock", 0.2, 2);
+        assert id2 == null;
+        System.out.println("Failed to acquire as expected.");
+
+        System.out.println("Releasing with wrong identifier (should fail)...");
+        assert !Chapter11.releaseLock(conn, "testlock", "wrong-id");
+
+        System.out.println("Releasing with correct identifier (should succeed)...");
+        assert Chapter11.releaseLock(conn, "testlock", id1);
+
+        System.out.println("Acquiring again (should succeed)...");
+        String id3 = Chapter11.acquireLockWithTimeout(conn, "testlock", 2, 1);
+        assert id3 != null;
+        System.out.println("Got lock id: " + id3);
+
+        System.out.println("Waiting lock to expire...");
+        Thread.sleep(1200);
+
+        System.out.println("After expiry, acquiring should succeed...");
+        String id4 = Chapter11.acquireLockWithTimeout(conn, "testlock", 2, 1);
+        assert id4 != null;
+        System.out.println("Got lock id: " + id4);
+
+        conn.del("lock:testlock");
+        System.out.println("Lua lock OK.");
+    }
+
+    public void testCountingSemaphoreLua(Jedis conn) throws InterruptedException {
+        System.out.println("\n----- testCountingSemaphoreLua -----");
+
+        conn.del("testsem");
+
+        System.out.println("Acquire 3 semaphores (limit=3)...");
+        String a = Chapter11.acquireSemaphore(conn, "testsem", 3, 1.0);
+        String b = Chapter11.acquireSemaphore(conn, "testsem", 3, 1.0);
+        String c = Chapter11.acquireSemaphore(conn, "testsem", 3, 1.0);
+        assert a != null && b != null && c != null;
+        System.out.println("Got: " + a + ", " + b + ", " + c);
+
+        System.out.println("Acquire 4th (should fail)...");
+        String d = Chapter11.acquireSemaphore(conn, "testsem", 3, 1.0);
+        assert d == null;
+        System.out.println("Failed as expected.");
+
+        System.out.println("Refreshing one token (should succeed)...");
+        assert Chapter11.refreshSemaphore(conn, "testsem", a);
+
+        System.out.println("Wait for timeout > 1s, old tokens should expire...");
+        Thread.sleep(1200);
+
+        System.out.println("Try acquire again after timeout...");
+        String e = Chapter11.acquireSemaphore(conn, "testsem", 3, 1.0);
+        assert e != null;
+        System.out.println("Got new token: " + e);
+
+        conn.del("testsem");
+        System.out.println("Lua semaphore OK.");
+    }
+
+    public void testAutocompleteLua(Jedis conn) {
+        System.out.println("\n----- testAutocompleteLua -----");
+
+        conn.del("members:g1");
+
+        System.out.println("Prefix range for 'abc' => " + Arrays.toString(Chapter11.findPrefixRange("abc")));
+
+        System.out.println("Adding members...");
+        conn.zadd("members:g1", 0, "jeff");
+        conn.zadd("members:g1", 0, "jenny");
+        conn.zadd("members:g1", 0, "jack");
+        conn.zadd("members:g1", 0, "jennifer");
+        conn.zadd("members:g1", 0, "john");
+
+        System.out.println("Autocomplete 'je' (expect: jeff/jenny/jennifer)...");
+        List<String> r = Chapter11.autocompleteOnPrefix(conn, "g1", "je");
+        System.out.println("Result => " + r);
+        assert r.contains("jeff");
+        assert r.contains("jenny");
+        assert r.contains("jennifer");
+        assert r.size() >= 3;
+
+        System.out.println("Autocomplete 'ja' (expect: jack)...");
+        List<String> r2 = Chapter11.autocompleteOnPrefix(conn, "g1", "ja");
+        System.out.println("Result => " + r2);
+        assert r2.contains("jack");
+
+        conn.del("members:g1");
+        System.out.println("Lua autocomplete OK.");
+    }
+
+    public void testPurchaseItemLua(Jedis conn) {
+        System.out.println("\n----- testPurchaseItemLua -----");
+
+        conn.del("market:", "user:buyer", "user:seller", "inventory:buyer");
+
+        conn.hset("user:buyer", "funds", "5");
+        conn.hset("user:seller", "funds", "0");
+
+        conn.zadd("market:", 10, "itemX.seller");
+
+        System.out.println("Buyer funds=5, price=10 => purchase should fail (nil)...");
+        boolean ok1 = Chapter11.purchaseItem(conn, "buyer", "itemX", "seller");
+        System.out.println("purchase result => " + ok1);
+        assert !ok1;
+
+        System.out.println("Add funds to buyer, set funds=20...");
+        conn.hset("user:buyer", "funds", "20");
+
+        System.out.println("Purchase should succeed...");
+        boolean ok2 = Chapter11.purchaseItem(conn, "buyer", "itemX", "seller");
+        System.out.println("purchase result => " + ok2);
+        assert ok2;
+
+        String buyerFunds = conn.hget("user:buyer", "funds");
+        String sellerFunds = conn.hget("user:seller", "funds");
+        System.out.println("buyer funds => " + buyerFunds + ", seller funds => " + sellerFunds);
+
+        assert "10".equals(buyerFunds);
+        assert "10".equals(sellerFunds);
+
+        boolean inInv = conn.sismember("inventory:buyer", "itemX");
+        System.out.println("inventory contains itemX => " + inInv);
+        assert inInv;
+
+        Double stillInMarket = conn.zscore("market:", "itemX.seller");
+        System.out.println("market still has item? => " + stillInMarket);
+        assert stillInMarket == null;
+
+        conn.del("market:", "user:buyer", "user:seller", "inventory:buyer");
+        System.out.println("Lua purchaseItem OK.");
+    }
+
+    public void testShardedListPushPop(Jedis conn) {
+        System.out.println("\n----- testShardedListPushPop -----");
+
+        String key = "sh:list";
+        deleteByPrefix(conn, key + ":");
+
+        String originalMax = null;
+        try {
+            List<String> cfg = conn.configGet("list-max-ziplist-entries");
+            if (cfg != null && cfg.size() >= 2) {
+                originalMax = cfg.get(1);
+                System.out.println("Original list-max-ziplist-entries => " + originalMax);
+                conn.configSet("list-max-ziplist-entries", "8");
+                System.out.println("Temporarily set list-max-ziplist-entries => 8");
+            }
+        } catch (Exception e) {
+            System.out.println("CONFIG SET not permitted, continue with default config.");
+        }
+
+        String[] items = new String[30];
+        for (int i = 0; i < items.length; i++) items[i] = String.valueOf(i + 1);
+
+        long pushed = Chapter11.shardedRpush(conn, key, items);
+        System.out.println("shardedRpush pushed => " + pushed);
+        assert pushed == 30;
+
+        for (int i = 1; i <= 30; i++) {
+            String v = Chapter11.shardedLPop(conn, key);
+            assert String.valueOf(i).equals(v);
+        }
+        assert Chapter11.shardedLPop(conn, key) == null;
+
+        List<String> letters = new ArrayList<String>();
+        for (char c = 'A'; c <= 'Z'; c++) letters.add(String.valueOf(c));
+
+        long pushed2 = Chapter11.shardedLpush(conn, key, letters.toArray(new String[0]));
+        System.out.println("shardedLpush pushed => " + pushed2);
+        assert pushed2 == 26;
+
+        for (int i = 0; i < 26; i++) {
+            String v = Chapter11.shardedRPop(conn, key);
+            assert letters.get(i).equals(v);
+        }
+        assert Chapter11.shardedRPop(conn, key) == null;
+
+        if (originalMax != null) {
+            try {
+                conn.configSet("list-max-ziplist-entries", originalMax);
+                System.out.println("Restored list-max-ziplist-entries => " + originalMax);
+            } catch (Exception ignore) {
+            }
+        }
+
+        deleteByPrefix(conn, key + ":");
+        System.out.println("Sharded list push/pop OK.");
+    }
+
+    public void testShardedBlockingPop(final Jedis conn) throws Exception {
+        System.out.println("\n----- testShardedBlockingPop -----");
+
+        final String key = "sh:block";
+        deleteByPrefix(conn, key + ":");
+
+        Thread producer1 = new Thread(new Runnable() {
+            public void run() {
+                Jedis c = null;
+                try {
+                    Thread.sleep(500);
+                    c = new Jedis("localhost");
+                    c.select(15);
+                    Chapter11.shardedRpush(c, key, "hello");
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    if (c != null) {
+                        try {
+                            c.disconnect();
+                        } catch (Exception ignore) {
+                        }
+                    }
+                }
+            }
+        });
+        producer1.start();
+
+        System.out.println("Calling shardedBlpop(timeout=3)...");
+        String v1 = Chapter11.shardedBlpop(conn, key, 3);
+        System.out.println("shardedBlpop got => " + v1);
+        assert "hello".equals(v1);
+
+        Thread producer2 = new Thread(new Runnable() {
+            public void run() {
+                Jedis c = null;
+                try {
+                    Thread.sleep(500);
+                    c = new Jedis("localhost");
+                    c.select(15);
+                    Chapter11.shardedLpush(c, key, "world");
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    if (c != null) {
+                        try {
+                            c.disconnect();
+                        } catch (Exception ignore) {
+                        }
+                    }
+                }
+            }
+        });
+        producer2.start();
+
+        System.out.println("Calling shardedBrpop(timeout=3)...");
+        String v2 = Chapter11.shardedBrpop(conn, key, 3);
+        System.out.println("shardedBrpop got => " + v2);
+        assert "world".equals(v2);
+
+        producer1.join();
+        producer2.join();
+
+        assert Chapter11.shardedLPop(conn, key) == null;
+        assert Chapter11.shardedRPop(conn, key) == null;
+
+        deleteByPrefix(conn, key + ":");
+        System.out.println("Sharded list blocking pop OK.");
+    }
+
+
+    private void deleteByPrefix(Jedis conn, String prefix) {
+        Set<String> keys = conn.keys(prefix + "*");
+        if (keys != null && !keys.isEmpty()) {
+            conn.del(keys.toArray(new String[0]));
+        }
+    }
+
+    public static ScriptFn scriptLoad(String script) {
+        AtomicReference<String> sha = new AtomicReference<String>(null);
+        return new ScriptFn() {
+            @Override
+            public Object call(Jedis conn, List<String> keys, List<String> args, boolean force_eval) {
+                if (keys == null) {
+                    keys = Collections.emptyList();
+                }
+                if (args == null) {
+                    args = Collections.emptyList();
+                }
+                if (force_eval) {
+                    return conn.eval(script, keys, args);
+                }
+                if (sha.get() == null) {
+                    String loadedSha = conn.scriptLoad(script);
+                    sha.set(loadedSha);
+                }
+                try {
+                    return conn.evalsha(sha.get(), keys, args);
+                } catch (JedisDataException e) {
+                    String msg = e.getMessage();
+                    if (msg == null || !msg.startsWith("NOSCRIPT")) {
+                        throw e;
+                    }
+                    return conn.eval(script, keys, args);
+                }
+            }
+
+            @Override
+            public Object call(Jedis conn, List<String> keys, List<String> args) {
+                return call(conn, keys, args, false);
+            }
+
+            @Override
+            public Object call(Jedis conn) {
+                return call(conn, Collections.emptyList(), Collections.emptyList(), false);
+            }
+        };
+    }
+
+    public interface ScriptFn {
+        Object call(Jedis conn, List<String> keys, List<String> args, boolean force_eval);
+
+        Object call(Jedis conn, List<String> keys, List<String> args);
+
+        Object call(Jedis conn);
+    }
+
+    private static final ScriptFn createStatusLua = scriptLoad(
+            "local login = redis.call('hget', KEYS[1], 'login')\n" +
+                    "if not login then\n" +
+                    "    return false\n" +
+                    "end\n" +
+                    "local id = redis.call('incr', KEYS[2])\n" +
+                    "local key = string.format('status:%s', id)\n" +
+                    "redis.call('hmset', key,\n" +
+                    "    'login', login,\n" +
+                    "    'id', id,\n" +
+                    "    unpack(ARGV)\n" +
+                    ")\n" +
+                    "redis.call('hincrby', KEYS[1], 'posts', 1)\n" +
+                    "return id\n"
+    );
+
+    public static Long createStatus(Jedis conn, String uid, String message, Map<String, String> data) {
+        List<String> args = new ArrayList<String>();
+        args.add("message");
+        args.add(message);
+        long posted = System.currentTimeMillis() / 1000;
+        args.add("posted");
+        args.add(String.valueOf(posted));
+        args.add("uid");
+        args.add(uid);
+        if (data != null) {
+            for (Map.Entry<String, String> entry : data.entrySet()) {
+                args.add(entry.getKey());
+                args.add(entry.getValue());
+            }
+        }
+        List<String> keys = Arrays.asList("user:" + uid, "status:id:");
+        Object result = createStatusLua.call(conn, keys, args);
+        if (result == null) {
+            return null;
+        }
+        if (result instanceof Long) {
+            return (Long) result;
+        }
+        return Long.parseLong(String.valueOf(result));
+    }
+
+    public static Long createStatus(Jedis conn, String uid, String message) {
+        return createStatus(conn, uid, message, null);
+    }
+
+    private static final ScriptFn acquireLockWithTimeoutLua = scriptLoad(
+            "if redis.call('exists',KEYS[1]) == 0 then\n" +
+                    "   return redis.call('setex',KEYS[1],unpack(ARGV))\n" +
+                    "end\n" +
+                    "return nil\n"
+    );
+
+    public static String acquireLockWithTimeout(Jedis conn, String lockname, double acquireTimeout, double lockTimeout) {
+        String identifier = UUID.randomUUID().toString();
+        String lockKey = "lock:" + lockname;
+        int lockTimeoutCeil = (int) Math.ceil(lockTimeout);
+        boolean acquired = false;
+        long end = System.currentTimeMillis() + (long) (acquireTimeout * 1000);
+        List<String> keys = Collections.singletonList(lockKey);
+        while (System.currentTimeMillis() < end && !acquired) {
+            List<String> args = Arrays.asList(String.valueOf(lockTimeoutCeil), identifier);
+            Object response = acquireLockWithTimeoutLua.call(conn, keys, args);
+            acquired = (response != null) && "OK".equals(String.valueOf(response));
+            if (!acquired) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return null;
+                }
+            }
+        }
+        return acquired ? identifier : null;
+    }
+
+    public static String acquireLockWithTimeout(Jedis conn, String lockname) {
+        return acquireLockWithTimeout(conn, lockname, 10, 10);
+    }
+
+    private static final ScriptFn releaseLockLua = scriptLoad(
+            "if redis.call('get',KEYS[1]) == ARGV[1] then\n" +
+                    "   return redis.call('del',KEYS[1])\n" +
+                    "end\n" +
+                    "return false\n"
+    );
+
+    public static boolean releaseLock(Jedis conn, String lockname, String identifier) {
+        String lockKey = "lock:" + lockname;
+        Object response = releaseLockLua.call(conn,
+                Collections.singletonList(lockKey),
+                Collections.singletonList(identifier)
+        );
+        if (response == null) {
+            return false;
+        }
+        if (response instanceof Boolean) {
+            return (Boolean) response;
+        }
+        String str = String.valueOf(response);
+        if ("false".equalsIgnoreCase(str) || "nil".equalsIgnoreCase(str)) {
+            return false;
+        }
+        try {
+            return Long.parseLong(str) > 0;
+        } catch (NumberFormatException e) {
+            return true;
+        }
+    }
+
+    private static final ScriptFn acquireSemaphoreLua = scriptLoad(
+            "redis.call('zremrangebyscore',KEYS[1],'-inf',ARGV[1])\n" +
+                    "if redis.call('zcard',KEYS[1]) < tonumber(ARGV[2]) then\n" +
+                    "   redis.call('zadd',KEYS[1],ARGV[3],ARGV[4])\n" +
+                    "   return ARGV[4]\n" +
+                    "end\n" +
+                    "return nil\n"
+    );
+
+    public static String acquireSemaphore(Jedis conn, String semname, long limit, double timeout) {
+        double now = System.currentTimeMillis() / 1000.0;
+        String identifier = UUID.randomUUID().toString();
+        List<String> keys = Collections.singletonList(semname);
+        List<String> args = Arrays.asList(
+                String.valueOf(now - timeout),
+                String.valueOf(limit),
+                String.valueOf(now),
+                identifier
+        );
+        Object response = acquireSemaphoreLua.call(conn, keys, args);
+        return (response == null) ? null : String.valueOf(response);
+    }
+
+    public static String acquireSemaphore(Jedis conn, String semname, long limit) {
+        return acquireSemaphore(conn, semname, limit, 10);
+    }
+
+    private static final ScriptFn refreshSemaphoreLua = scriptLoad(
+            "if redis.call('zscore',KEYS[1],ARGV[1]) then\n" +
+                    "   return redis.call('zadd',KEYS[1],ARGV[2],ARGV[1]) or true\n" +
+                    "end\n" +
+                    "return nil\n"
+    );
+
+    public static boolean refreshSemaphore(Jedis conn, String semname, String identifier) {
+        double now = System.currentTimeMillis() / 1000.0;
+        Object response = refreshSemaphoreLua.call(
+                conn,
+                Collections.singletonList(semname),
+                Arrays.asList(identifier, String.valueOf(now))
+        );
+        return response != null;
+    }
+
+    private static final ScriptFn autocompleteOnPrefixLua = scriptLoad(
+            "redis.call('zadd',KEYS[1],0,ARGV[1],0,ARGV[2])\n" +
+                    "local sindex = redis.call('zrank',KEYS[1],ARGV[1])\n" +
+                    "local eindex = redis.call('zrank',KEYS[1],ARGV[2])\n" +
+                    "local orange = math.min(sindex + 9, eindex - 2)\n" +
+                    "redis.call('zrem',KEYS[1],unpack(ARGV))\n" +
+                    "return redis.call('zrange',KEYS[1],sindex,orange)\n"
+    );
+
+    public static List<String> autocompleteOnPrefix(Jedis conn, String guild, String prefix) {
+        String[] range = findPrefixRange(prefix);
+        String start = range[0];
+        String end = range[1];
+
+        String identifier = UUID.randomUUID().toString();
+        List<String> keys = Collections.singletonList("members:" + guild);
+        List<String> args = Arrays.asList(start + identifier, end + identifier);
+        Object response = autocompleteOnPrefixLua.call(conn, keys, args);
+        List<String> items = castStringList(response);
+
+        List<String> out = new ArrayList<String>(items.size());
+        for (String item : items) {
+            if (item != null && item.indexOf('{') < 0) {
+                out.add(item);
+            }
+        }
+        return out;
+    }
+
+    public static String[] findPrefixRange(String prefix) {
+        if (prefix == null || prefix.trim().length() == 0) {
+            throw new IllegalArgumentException("prefix must not be empty");
+        }
+        prefix = prefix.toLowerCase(Locale.ROOT);
+        char last = prefix.charAt(prefix.length() - 1);
+        int posn = VALID_CHARACTERS.indexOf(last);
+        if (posn < 0) {
+            throw new IllegalArgumentException("invalid character in prefix: " + last);
+        }
+        char suffix = VALID_CHARACTERS.charAt(posn > 0 ? posn - 1 : 0);
+        String start = prefix.substring(0, prefix.length() - 1) + suffix + "{";
+        String end = prefix + "{";
+        return new String[]{start, end};
+    }
+
+    private static List<String> castStringList(Object response) {
+        if (response == null) return Collections.emptyList();
+        if (response instanceof List<?>) {
+            List<?> raw = (List<?>) response;
+            List<String> out = new ArrayList<String>(raw.size());
+            for (Object o : raw) {
+                out.add(o == null ? null : String.valueOf(o));
+            }
+            return out;
+        }
+        return Collections.singletonList(response.toString());
+    }
+
+    private static final ScriptFn purchaseItemLua = scriptLoad(
+            "local price = tonumber(redis.call('zscore',KEYS[1],ARGV[1]))\n" +
+                    "if not price then\n" +
+                    "   return 0\n" +
+                    "end\n" +
+                    "local funds = tonumber(redis.call('hget',KEYS[2],'funds'))\n" +
+                    "if (not funds) or (funds < price) then\n" +
+                    "   return nil\n" +
+                    "end\n" +
+                    "redis.call('hincrby',KEYS[3],'funds',price)\n" +
+                    "redis.call('hincrby',KEYS[2],'funds',-price)\n" +
+                    "redis.call('sadd',KEYS[4],ARGV[2])\n" +
+                    "redis.call('zrem',KEYS[1],ARGV[1])\n" +
+                    "return true\n"
+    );
+
+    public static boolean purchaseItem(Jedis conn, String buyerId, String itemId, String sellerId) {
+        String buyer = "user:" + buyerId;
+        String seller = "user:" + sellerId;
+        String item = itemId + "." + sellerId;
+        String inventory = "inventory:" + buyerId;
+
+        List<String> keys = Arrays.asList("market:", buyer, seller, inventory);
+        List<String> args = Arrays.asList(item, itemId);
+
+        Object response = purchaseItemLua.call(conn, keys, args);
+        return response != null;
+    }
+
+    private static final ScriptFn shardedPushLua = scriptLoad(
+            "local max = tonumber(redis.call('config','get','list-max-ziplist-entries')[2])\n" +
+                    "if #ARGV < 2 or max < 2 then return 0 end\n" +
+                    "local skey = ARGV[1] == 'lpush' and KEYS[2] or KEYS[3]\n" +
+                    "local shard = redis.call('get', skey) or '0'\n" +
+                    "while 1 do\n" +
+                    "  local current = tonumber(redis.call('llen', KEYS[1] .. shard))\n" +
+                    "  local topush = math.min(#ARGV - 1, max - current - 1)\n" +
+                    "  if topush > 0 then\n" +
+                    "    redis.call(ARGV[1], KEYS[1] .. shard, unpack(ARGV, 2, topush + 1))\n" +
+                    "    return topush\n" +
+                    "  end\n" +
+                    "  shard = redis.call(ARGV[1] == 'lpush' and 'decr' or 'incr', skey)\n" +
+                    "end\n"
+    );
+
+    public static long shardedPushHelper(Jedis conn, String key, String cmd, String... items) {
+        List<String> itemList = new ArrayList<String>();
+        if (items != null) {
+            Collections.addAll(itemList, items);
+        }
+        long total = 0;
+        List<String> keys = Arrays.asList(key + ":", key + ":first", key + ":last");
+        while (!itemList.isEmpty()) {
+            int end = Math.min(PUSH_CHUNK_SIZE, itemList.size());
+            List<String> args = new ArrayList<String>(end + 1);
+            args.add(cmd);
+            args.addAll(itemList.subList(0, end));
+            Object pushed = shardedPushLua.call(conn, keys, args);
+            total += (Long) pushed;
+            itemList.subList(0, end).clear();
+        }
+        return total;
+    }
+
+    public static long shardedLpush(Jedis conn, String key, String... items) {
+        return shardedPushHelper(conn, key, "lpush", items);
+    }
+
+    public static long shardedRpush(Jedis conn, String key, String... items) {
+        return shardedPushHelper(conn, key, "rpush", items);
+    }
+
+    private static final ScriptFn shardedListPopLua = scriptLoad(
+            "local skey = ARGV[1] == 'lpop' and KEYS[2] or KEYS[3]\n" +
+                    "local shard = redis.call('get', skey) or '0'\n" +
+                    "local ret = redis.call(ARGV[1], KEYS[1] .. shard)\n" +
+                    "if not ret or redis.call('llen', KEYS[1] .. shard) == 0 then\n" +
+                    "    local oshard = redis.call('get', skey) or '0'\n" +
+                    "    if shard == oshard then\n" +
+                    "        return ret\n" +
+                    "    end\n" +
+                    "end\n" +
+                    "local cmd = ARGV[1] == 'lpop' and 'decr' or 'incr'\n" +
+                    "shard = redis.call(cmd, skey)\n" +
+                    "if not ret then\n" +
+                    "    ret = redis.call(ARGV[1], KEYS[1] .. shard)\n" +
+                    "end\n" +
+                    "return ret"
+    );
+
+    public static String shardedLPop(Jedis conn, String key) {
+        List<String> keys = Arrays.asList(key + ":", key + ":first", key + ":last");
+        List<String> args = Collections.singletonList("lpop");
+        Object response = shardedListPopLua.call(conn, keys, args);
+        return (response == null) ? null : String.valueOf(response);
+    }
+
+    public static String shardedRPop(Jedis conn, String key) {
+        List<String> keys = Arrays.asList(key + ":", key + ":first", key + ":last");
+        List<String> args = Collections.singletonList("rpop");
+        Object response = shardedListPopLua.call(conn, keys, args);
+        return (response == null) ? null : String.valueOf(response);
+    }
+
+    private static final ScriptFn shardedBpopHelperLua = scriptLoad(
+
+            "local shard = redis.call('get', KEYS[2]) or '0'\n" +
+                    "if shard ~= ARGV[1] then\n" +
+                    "    redis.call(ARGV[2], KEYS[1], ARGV[3])\n" +
+                    "end\n"
+    );
+
+    public static String shardedBpopHelper(Jedis conn, String key, int timeout, boolean isLeft) {
+        int t = Math.max(timeout, 0);
+        if (t == 0) t = 2 * 64;
+        long end = System.currentTimeMillis() + t * 1000L;
+
+        String endp = isLeft ? ":first" : ":last";
+        String pushCmd = isLeft ? "lpush" : "rpush";
+
+        while (System.currentTimeMillis() < end) {
+            String result = isLeft ? shardedLPop(conn, key) : shardedRPop(conn, key);
+            if (result != null && !DUMMY.equals(result)) {
+                return result;
+            }
+
+            String shard = conn.get(key + endp);
+            if (shard == null) shard = "0";
+            String shardListKey = key + ":" + shard;
+
+            shardedBpopHelperLua.call(conn,
+                    Arrays.asList(shardListKey, key + endp),
+                    Arrays.asList(shard, pushCmd, DUMMY),
+                    true);
+
+            List<String> r = isLeft ? conn.blpop(1, shardListKey) : conn.brpop(1, shardListKey);
+            if (r != null && r.size() == 2) {
+                String val = r.get(1);
+                if (!DUMMY.equals(val)) {
+                    return val;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String shardedBlpop(Jedis conn, String key, int timeout) {
+        return shardedBpopHelper(conn, key, timeout, true);
+    }
+
+    public static String shardedBrpop(Jedis conn, String key, int timeout) {
+        return shardedBpopHelper(conn, key, timeout, false);
+    }
+}

--- a/java/src/main/java/Chapter11.java
+++ b/java/src/main/java/Chapter11.java
@@ -14,6 +14,7 @@ public class Chapter11 {
         new Chapter11().run();
     }
 
+    // Execute all test methods sequentially.
     public void run() throws Exception {
         Jedis conn = new Jedis("localhost");
         conn.select(15);
@@ -33,6 +34,7 @@ public class Chapter11 {
         System.out.println("\nALL Chapter 11 tests passed.");
     }
 
+    // Test the script loading mechanism.
     public void testScriptLoad(Jedis conn) {
         System.out.println("\n----- testScriptLoad -----");
         Chapter11.ScriptFn fn = Chapter11.scriptLoad("return 1");
@@ -53,6 +55,7 @@ public class Chapter11 {
         System.out.println("scriptLoad() OK.");
     }
 
+    // Test creating a status message with Lua.
     public void testCreateStatus(Jedis conn) {
         System.out.println("\n----- testCreateStatus -----");
 
@@ -90,6 +93,7 @@ public class Chapter11 {
         System.out.println("createStatus() OK.");
     }
 
+    // Test distributed lock using Lua.
     public void testDistributedLockingLua(Jedis conn) throws InterruptedException {
         System.out.println("\n----- testDistributedLockingLua -----");
 
@@ -128,6 +132,7 @@ public class Chapter11 {
         System.out.println("Lua lock OK.");
     }
 
+    // Test counting semaphore using Lua.
     public void testCountingSemaphoreLua(Jedis conn) throws InterruptedException {
         System.out.println("\n----- testCountingSemaphoreLua -----");
 
@@ -160,6 +165,7 @@ public class Chapter11 {
         System.out.println("Lua semaphore OK.");
     }
 
+    // Test autocomplete using Lua.
     public void testAutocompleteLua(Jedis conn) {
         System.out.println("\n----- testAutocompleteLua -----");
 
@@ -191,6 +197,7 @@ public class Chapter11 {
         System.out.println("Lua autocomplete OK.");
     }
 
+    // Test purchase item using Lua.
     public void testPurchaseItemLua(Jedis conn) {
         System.out.println("\n----- testPurchaseItemLua -----");
 
@@ -233,6 +240,7 @@ public class Chapter11 {
         System.out.println("Lua purchaseItem OK.");
     }
 
+    // Test sharded list push/pop operations.
     public void testShardedListPushPop(Jedis conn) {
         System.out.println("\n----- testShardedListPushPop -----");
 
@@ -290,6 +298,7 @@ public class Chapter11 {
         System.out.println("Sharded list push/pop OK.");
     }
 
+    // Test blocking pop on sharded lists.
     public void testShardedBlockingPop(final Jedis conn) throws Exception {
         System.out.println("\n----- testShardedBlockingPop -----");
 
@@ -360,7 +369,7 @@ public class Chapter11 {
         System.out.println("Sharded list blocking pop OK.");
     }
 
-
+    // Delete all keys with a given prefix.
     private void deleteByPrefix(Jedis conn, String prefix) {
         Set<String> keys = conn.keys(prefix + "*");
         if (keys != null && !keys.isEmpty()) {
@@ -368,6 +377,7 @@ public class Chapter11 {
         }
     }
 
+    // Return a function that loads and executes a Lua script.
     public static ScriptFn scriptLoad(String script) {
         AtomicReference<String> sha = new AtomicReference<String>(null);
         return new ScriptFn() {
@@ -409,14 +419,14 @@ public class Chapter11 {
         };
     }
 
+    // Interface for script-calling functions.
     public interface ScriptFn {
         Object call(Jedis conn, List<String> keys, List<String> args, boolean force_eval);
-
         Object call(Jedis conn, List<String> keys, List<String> args);
-
         Object call(Jedis conn);
     }
 
+    // Lua script for creating a status message.
     private static final ScriptFn createStatusLua = scriptLoad(
             "local login = redis.call('hget', KEYS[1], 'login')\n" +
                     "if not login then\n" +
@@ -433,6 +443,7 @@ public class Chapter11 {
                     "return id\n"
     );
 
+    // Create a status message using Lua script.
     public static Long createStatus(Jedis conn, String uid, String message, Map<String, String> data) {
         List<String> args = new ArrayList<String>();
         args.add("message");
@@ -459,10 +470,12 @@ public class Chapter11 {
         return Long.parseLong(String.valueOf(result));
     }
 
+    // Create a status message with only required fields.
     public static Long createStatus(Jedis conn, String uid, String message) {
         return createStatus(conn, uid, message, null);
     }
 
+    // Lua script for acquiring a lock with timeout.
     private static final ScriptFn acquireLockWithTimeoutLua = scriptLoad(
             "if redis.call('exists',KEYS[1]) == 0 then\n" +
                     "   return redis.call('setex',KEYS[1],unpack(ARGV))\n" +
@@ -470,6 +483,7 @@ public class Chapter11 {
                     "return nil\n"
     );
 
+    // Acquire a distributed lock using Lua script.
     public static String acquireLockWithTimeout(Jedis conn, String lockname, double acquireTimeout, double lockTimeout) {
         String identifier = UUID.randomUUID().toString();
         String lockKey = "lock:" + lockname;
@@ -493,10 +507,12 @@ public class Chapter11 {
         return acquired ? identifier : null;
     }
 
+    // Acquire a lock with default timeouts.
     public static String acquireLockWithTimeout(Jedis conn, String lockname) {
         return acquireLockWithTimeout(conn, lockname, 10, 10);
     }
 
+    // Lua script for releasing a lock.
     private static final ScriptFn releaseLockLua = scriptLoad(
             "if redis.call('get',KEYS[1]) == ARGV[1] then\n" +
                     "   return redis.call('del',KEYS[1])\n" +
@@ -504,6 +520,7 @@ public class Chapter11 {
                     "return false\n"
     );
 
+    // Release a distributed lock using Lua script.
     public static boolean releaseLock(Jedis conn, String lockname, String identifier) {
         String lockKey = "lock:" + lockname;
         Object response = releaseLockLua.call(conn,
@@ -527,6 +544,7 @@ public class Chapter11 {
         }
     }
 
+    // Lua script for acquiring a counting semaphore.
     private static final ScriptFn acquireSemaphoreLua = scriptLoad(
             "redis.call('zremrangebyscore',KEYS[1],'-inf',ARGV[1])\n" +
                     "if redis.call('zcard',KEYS[1]) < tonumber(ARGV[2]) then\n" +
@@ -536,6 +554,7 @@ public class Chapter11 {
                     "return nil\n"
     );
 
+    // Acquire a counting semaphore using Lua script.
     public static String acquireSemaphore(Jedis conn, String semname, long limit, double timeout) {
         double now = System.currentTimeMillis() / 1000.0;
         String identifier = UUID.randomUUID().toString();
@@ -550,10 +569,12 @@ public class Chapter11 {
         return (response == null) ? null : String.valueOf(response);
     }
 
+    // Acquire a semaphore with default timeout.
     public static String acquireSemaphore(Jedis conn, String semname, long limit) {
         return acquireSemaphore(conn, semname, limit, 10);
     }
 
+    // Lua script for refreshing a semaphore.
     private static final ScriptFn refreshSemaphoreLua = scriptLoad(
             "if redis.call('zscore',KEYS[1],ARGV[1]) then\n" +
                     "   return redis.call('zadd',KEYS[1],ARGV[2],ARGV[1]) or true\n" +
@@ -561,6 +582,7 @@ public class Chapter11 {
                     "return nil\n"
     );
 
+    // Refresh a semaphore's timestamp.
     public static boolean refreshSemaphore(Jedis conn, String semname, String identifier) {
         double now = System.currentTimeMillis() / 1000.0;
         Object response = refreshSemaphoreLua.call(
@@ -571,6 +593,7 @@ public class Chapter11 {
         return response != null;
     }
 
+    // Lua script for autocomplete on prefix.
     private static final ScriptFn autocompleteOnPrefixLua = scriptLoad(
             "redis.call('zadd',KEYS[1],0,ARGV[1],0,ARGV[2])\n" +
                     "local sindex = redis.call('zrank',KEYS[1],ARGV[1])\n" +
@@ -580,6 +603,7 @@ public class Chapter11 {
                     "return redis.call('zrange',KEYS[1],sindex,orange)\n"
     );
 
+    // Get autocomplete suggestions for a prefix.
     public static List<String> autocompleteOnPrefix(Jedis conn, String guild, String prefix) {
         String[] range = findPrefixRange(prefix);
         String start = range[0];
@@ -600,6 +624,7 @@ public class Chapter11 {
         return out;
     }
 
+    // Find the lexicographic range for a given prefix.
     public static String[] findPrefixRange(String prefix) {
         if (prefix == null || prefix.trim().length() == 0) {
             throw new IllegalArgumentException("prefix must not be empty");
@@ -616,6 +641,7 @@ public class Chapter11 {
         return new String[]{start, end};
     }
 
+    // Safely cast a script response to a list of strings.
     private static List<String> castStringList(Object response) {
         if (response == null) return Collections.emptyList();
         if (response instanceof List<?>) {
@@ -629,6 +655,7 @@ public class Chapter11 {
         return Collections.singletonList(response.toString());
     }
 
+    // Lua script for purchasing an item from market.
     private static final ScriptFn purchaseItemLua = scriptLoad(
             "local price = tonumber(redis.call('zscore',KEYS[1],ARGV[1]))\n" +
                     "if not price then\n" +
@@ -645,6 +672,7 @@ public class Chapter11 {
                     "return true\n"
     );
 
+    // Purchase an item using Lua script.
     public static boolean purchaseItem(Jedis conn, String buyerId, String itemId, String sellerId) {
         String buyer = "user:" + buyerId;
         String seller = "user:" + sellerId;
@@ -658,6 +686,7 @@ public class Chapter11 {
         return response != null;
     }
 
+    // Lua script for pushing to a sharded list.
     private static final ScriptFn shardedPushLua = scriptLoad(
             "local max = tonumber(redis.call('config','get','list-max-ziplist-entries')[2])\n" +
                     "if #ARGV < 2 or max < 2 then return 0 end\n" +
@@ -674,6 +703,7 @@ public class Chapter11 {
                     "end\n"
     );
 
+    // Helper to push items onto a sharded list.
     public static long shardedPushHelper(Jedis conn, String key, String cmd, String... items) {
         List<String> itemList = new ArrayList<String>();
         if (items != null) {
@@ -693,14 +723,17 @@ public class Chapter11 {
         return total;
     }
 
+    // Left push onto a sharded list.
     public static long shardedLpush(Jedis conn, String key, String... items) {
         return shardedPushHelper(conn, key, "lpush", items);
     }
 
+    // Right push onto a sharded list.
     public static long shardedRpush(Jedis conn, String key, String... items) {
         return shardedPushHelper(conn, key, "rpush", items);
     }
 
+    // Lua script for popping from a sharded list.
     private static final ScriptFn shardedListPopLua = scriptLoad(
             "local skey = ARGV[1] == 'lpop' and KEYS[2] or KEYS[3]\n" +
                     "local shard = redis.call('get', skey) or '0'\n" +
@@ -719,6 +752,7 @@ public class Chapter11 {
                     "return ret"
     );
 
+    // Left pop from a sharded list.
     public static String shardedLPop(Jedis conn, String key) {
         List<String> keys = Arrays.asList(key + ":", key + ":first", key + ":last");
         List<String> args = Collections.singletonList("lpop");
@@ -726,6 +760,7 @@ public class Chapter11 {
         return (response == null) ? null : String.valueOf(response);
     }
 
+    // Right pop from a sharded list.
     public static String shardedRPop(Jedis conn, String key) {
         List<String> keys = Arrays.asList(key + ":", key + ":first", key + ":last");
         List<String> args = Collections.singletonList("rpop");
@@ -733,14 +768,15 @@ public class Chapter11 {
         return (response == null) ? null : String.valueOf(response);
     }
 
+    // Lua script for assisting blocking pop on sharded lists.
     private static final ScriptFn shardedBpopHelperLua = scriptLoad(
-
             "local shard = redis.call('get', KEYS[2]) or '0'\n" +
                     "if shard ~= ARGV[1] then\n" +
                     "    redis.call(ARGV[2], KEYS[1], ARGV[3])\n" +
                     "end\n"
     );
 
+    // Helper for blocking pop from a sharded list.
     public static String shardedBpopHelper(Jedis conn, String key, int timeout, boolean isLeft) {
         int t = Math.max(timeout, 0);
         if (t == 0) t = 2 * 64;
@@ -775,10 +811,12 @@ public class Chapter11 {
         return null;
     }
 
+    // Blocking left pop from a sharded list.
     public static String shardedBlpop(Jedis conn, String key, int timeout) {
         return shardedBpopHelper(conn, key, timeout, true);
     }
 
+    // Blocking right pop from a sharded list.
     public static String shardedBrpop(Jedis conn, String key, int timeout) {
         return shardedBpopHelper(conn, key, timeout, false);
     }


### PR DESCRIPTION
Thanks for maintaining Redis in Action and for sharing these examples with the community.
This PR adds the missing Java implementations for Chapter 10 (Chapter10.java) and Chapter 11 (Chapter11.java), organized to closely follow the book’s listings and structure. It also updates build.gradle so the existing chapter-based run workflow works for both single-digit chapters (01–09) and two-digit chapters (10+), without changing any existing Chapter 1–9 code.

I verified locally with Redis running:
- ./gradlew -Pchapter=1 run (unchanged behavior)
- ./gradlew -Pchapter=10 run (Chapter 10 tests complete)
- ./gradlew -Pchapter=11 run (Chapter 11 tests complete)